### PR TITLE
feat(graph): add Op::Fused and an opt-in elementwise-chain fusion pass

### DIFF
--- a/core/teeny-core/src/graph/mod.rs
+++ b/core/teeny-core/src/graph/mod.rs
@@ -395,6 +395,21 @@ pub enum Op {
         bn_eps: f64,
     },
 
+    /// A run of adjacent, single-input/single-output elementwise ops fused into one
+    /// kernel launch. Produced by `Graph::optimise()` when it finds a chain of nodes
+    /// whose ops are all eligible per [`is_fusable_elementwise`] and whose interior
+    /// nodes each have exactly one consumer (the next member in the chain).
+    ///
+    /// `members` is the chain in execution order; the fused node's single input feeds
+    /// `members[0]`, and each subsequent member consumes the previous member's output.
+    /// Lowering concatenates each member's kernel source into one compilation unit and
+    /// synthesizes a new entry point that calls them in sequence — see
+    /// `teeny-kernels/src/graph/mod.rs`'s `Op::Fused` lowering.
+    Fused {
+        /// The chain's ops, in execution order.
+        members: alloc::vec::Vec<Op>,
+    },
+
     // --- Pooling ---
     /// 1-D average pooling (see `nn::pool::AvgPool1d`).
     AvgPool1d {
@@ -1677,6 +1692,11 @@ impl Graph {
     ///
     /// Nodes that are absorbed into a fused node are removed from the output
     /// graph; remaining node indices are renumbered contiguously.
+    ///
+    /// This does *not* include [`Graph::fuse_elementwise_chains`] — that pass
+    /// produces `Op::Fused` nodes, and folding it in here would silently change
+    /// what every existing `optimise()` caller lowers to. Call it separately once
+    /// the target lowering backend actually knows how to compile `Op::Fused`.
     pub fn optimise(&self) -> Graph {
         let n = self.nodes.len();
 
@@ -1831,6 +1851,149 @@ impl Graph {
 
         new_graph
     }
+
+    /// Rewrite the graph by fusing adjacent, single-input/single-output elementwise
+    /// chains (see [`is_fusable_elementwise`]) into `Op::Fused` nodes.
+    ///
+    /// Separate from [`Graph::optimise`] on purpose: producing `Op::Fused` only helps
+    /// once a lowering backend knows how to compile it (concatenate each member's
+    /// kernel source and synthesize an entry point that runs them in sequence — see
+    /// the `Op::Fused` doc comment). Call this explicitly once that backend support
+    /// exists; don't fold it into `optimise()`, which every existing caller already
+    /// depends on producing today's set of ops.
+    ///
+    /// Iterates [`Graph::fuse_elementwise_chain_pass`] to a fixed point: each call
+    /// only merges one adjacent pair, so a chain longer than two nodes grows by one
+    /// member per iteration until nothing more merges.
+    pub fn fuse_elementwise_chains(&self) -> Graph {
+        let mut graph = self.clone();
+        loop {
+            let (next, changed) = graph.fuse_elementwise_chain_pass();
+            graph = next;
+            if !changed {
+                break;
+            }
+        }
+        graph
+    }
+
+    /// One round of adjacent-pair elementwise fusion: finds the first `(parent,
+    /// child)` pair where `child` is [`is_fusable_elementwise`], `child` has exactly
+    /// one input (`parent`), and `parent` has exactly one consumer (`child`), and
+    /// merges them into a single `Op::Fused` node — growing `parent`'s existing
+    /// `members` list if `parent` is itself already `Op::Fused`, or starting a new
+    /// one otherwise. Returns the rewritten graph and whether a merge happened;
+    /// `optimise()` calls this in a loop until it reports no change, so a chain
+    /// longer than two nodes is grown one pair at a time across repeated calls
+    /// rather than requiring a single-pass lookahead scan.
+    fn fuse_elementwise_chain_pass(&self) -> (Graph, bool) {
+        let n = self.nodes.len();
+
+        let mut n_consumers = vec![0usize; n];
+        for node in &self.nodes {
+            for &inp in &node.inputs {
+                n_consumers[inp] += 1;
+            }
+        }
+
+        let mut dead = vec![false; n];
+        let mut node_override: Vec<Option<(Op, Vec<usize>)>> = vec![None; n];
+        let mut changed = false;
+
+        // `child_idx` indexes multiple parallel collections below (self.nodes,
+        // n_consumers, node_override), not just one -- an iterator/enumerate() rewrite
+        // wouldn't be clearer.
+        #[allow(clippy::needless_range_loop)]
+        for child_idx in 0..n {
+            if changed {
+                break;
+            }
+            if !is_fusable_elementwise(&self.nodes[child_idx].op) {
+                continue;
+            }
+            if self.nodes[child_idx].inputs.len() != 1 {
+                continue;
+            }
+            let parent_idx = self.nodes[child_idx].inputs[0];
+            if n_consumers[parent_idx] != 1 {
+                continue;
+            }
+            let parent_op = &self.nodes[parent_idx].op;
+            let mut members = match parent_op {
+                Op::Fused { members } => members.clone(),
+                other if is_fusable_elementwise(other) => alloc::vec![other.clone()],
+                _ => continue,
+            };
+            members.push(self.nodes[child_idx].op.clone());
+
+            dead[parent_idx] = true;
+            node_override[child_idx] = Some((
+                Op::Fused { members },
+                self.nodes[parent_idx].inputs.clone(),
+            ));
+            changed = true;
+        }
+
+        if !changed {
+            return (self.clone(), false);
+        }
+
+        let mut old_to_new = vec![0usize; n];
+        let mut new_count = 0usize;
+        for i in 0..n {
+            if !dead[i] {
+                old_to_new[i] = new_count;
+                new_count += 1;
+            }
+        }
+
+        let mut new_graph = Graph::new();
+        for old_idx in 0..n {
+            if dead[old_idx] {
+                continue;
+            }
+            let node = &self.nodes[old_idx];
+            let (op, inputs) =
+                if let Some((fused_op, fused_inputs)) = node_override[old_idx].clone() {
+                    let mapped = fused_inputs.iter().map(|&i| old_to_new[i]).collect();
+                    (fused_op, mapped)
+                } else {
+                    let mapped = node.inputs.iter().map(|&i| old_to_new[i]).collect();
+                    (node.op.clone(), mapped)
+                };
+            let new_idx = new_graph.nodes.len();
+            new_graph.nodes.push(GraphNode {
+                op,
+                inputs,
+                dtype: node.dtype,
+                shape: node.shape.clone(),
+            });
+            if let Some(name) = self.names.get(&old_idx) {
+                new_graph.names.insert(new_idx, name.clone());
+            }
+        }
+
+        (new_graph, true)
+    }
+}
+
+/// Whether `op` is eligible to appear inside an `Op::Fused` chain.
+///
+/// Deliberately conservative: a fixed allowlist of simple, single-input/single-output
+/// activation ops that are (a) genuinely shape-preserving and (b) already dispatched
+/// through a uniform, fixed-block-size elementwise kernel (`BLOCK_SIZE = 1024`) in
+/// `teeny-kernels`, so every candidate is known to share the same CTA/thread structure
+/// without needing to consult a `RuntimeOp` (which doesn't exist yet at this point in
+/// the pipeline — `fuse_elementwise_chains()` runs on the `teeny-core::Op` graph, before
+/// `teeny-kernels`' lowering constructs any `RuntimeOp`). Excludes normalization ops
+/// (`BatchNorm*`, `LayerNorm`, ...) even though they're also shape-preserving: several
+/// of their `RuntimeOp` impls are unimplemented stubs today, and some aren't the plain
+/// fixed-block-size elementwise shape this allowlist is scoped to.
+pub fn is_fusable_elementwise(op: &Op) -> bool {
+    matches!(
+        op,
+        Op::Relu | Op::Sigmoid | Op::Silu | Op::Tanh
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -1849,6 +2012,12 @@ fn infer_output_shape(op: &Op, inputs: &[&Shape]) -> Shape {
     let input = inputs[0];
     match op {
         Op::Input => input.clone(),
+
+        Op::Fused { members } => members
+            .iter()
+            .fold(input.clone(), |shape, member| {
+                infer_output_shape(member, &[&shape])
+            }),
 
         // Element-wise / shape-preserving — output shape = input shape
         Op::Relu
@@ -3488,5 +3657,234 @@ mod tests {
         assert_eq!(g.nodes[11].shape, vec![None, Some(84)]);
         assert_eq!(g.nodes[12].shape, vec![None, Some(10)]);
         assert_eq!(g.nodes[13].shape, vec![None, Some(10)]);
+    }
+
+    // -----------------------------------------------------------------------
+    // is_fusable_elementwise / Op::Fused / Graph::fuse_elementwise_chains
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_fusable_elementwise_allowlist() {
+        assert!(is_fusable_elementwise(&Op::Relu));
+        assert!(is_fusable_elementwise(&Op::Sigmoid));
+        assert!(is_fusable_elementwise(&Op::Silu));
+        assert!(is_fusable_elementwise(&Op::Tanh));
+    }
+
+    #[test]
+    fn test_is_fusable_elementwise_excludes_non_allowlisted_ops() {
+        assert!(!is_fusable_elementwise(&Op::Input));
+        assert!(!is_fusable_elementwise(&Op::Gelu));
+        assert!(!is_fusable_elementwise(&Op::Softmax { dim: 1 }));
+        assert!(!is_fusable_elementwise(&Op::Conv2d {
+            in_channels: 3,
+            out_channels: 8,
+            kernel_h: 3,
+            kernel_w: 3,
+            stride_h: 1,
+            stride_w: 1,
+            padding_h: 1,
+            padding_w: 1,
+            groups: 1,
+            has_bias: false,
+        }));
+        assert!(!is_fusable_elementwise(&Op::BatchNorm2d {
+            num_features: 8,
+            eps: 1e-5,
+            momentum: 0.1,
+            affine: true,
+            track_running_stats: true,
+        }));
+        assert!(!is_fusable_elementwise(&Op::Linear {
+            in_features: 4,
+            out_features: 4,
+            has_bias: false,
+        }));
+    }
+
+    #[test]
+    fn test_infer_output_shape_fused_folds_through_members() {
+        let shape = vec![None, Some(16)];
+        let out = infer_output_shape(
+            &Op::Fused {
+                members: alloc::vec![Op::Relu, Op::Sigmoid, Op::Silu],
+            },
+            &[&shape],
+        );
+        // All three members are shape-preserving, so the fused node is too.
+        assert_eq!(out, shape);
+    }
+
+    fn shape_1d(n: usize) -> Shape {
+        vec![None, Some(n)]
+    }
+
+    #[test]
+    fn test_fuse_elementwise_chains_fuses_linear_chain() {
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(16));
+        let relu = g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(16));
+        let sigmoid = g.add_node(Op::Sigmoid, vec![relu], DtypeRepr::F32, shape_1d(16));
+        let _silu = g.add_node(Op::Silu, vec![sigmoid], DtypeRepr::F32, shape_1d(16));
+
+        let fused = g.fuse_elementwise_chains();
+
+        // Input + one Fused node.
+        assert_eq!(fused.nodes.len(), 2);
+        assert!(matches!(fused.nodes[0].op, Op::Input));
+        match &fused.nodes[1].op {
+            Op::Fused { members } => {
+                assert_eq!(members.len(), 3);
+                assert!(matches!(members[0], Op::Relu));
+                assert!(matches!(members[1], Op::Sigmoid));
+                assert!(matches!(members[2], Op::Silu));
+            }
+            other => panic!("expected Op::Fused, got {other:?}"),
+        }
+        // The fused node's input is the original Input node (rewired correctly).
+        assert_eq!(fused.nodes[1].inputs, vec![0]);
+    }
+
+    #[test]
+    fn test_fuse_elementwise_chains_no_fusion_for_single_op() {
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(16));
+        g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(16));
+
+        let fused = g.fuse_elementwise_chains();
+
+        assert_eq!(fused.nodes.len(), 2);
+        assert!(matches!(fused.nodes[1].op, Op::Relu));
+    }
+
+    #[test]
+    fn test_fuse_elementwise_chains_stops_at_non_fusable_op() {
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(4));
+        let relu = g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(4));
+        let conv = g.add_node(
+            Op::Conv2d {
+                in_channels: 4,
+                out_channels: 4,
+                kernel_h: 3,
+                kernel_w: 3,
+                stride_h: 1,
+                stride_w: 1,
+                padding_h: 1,
+                padding_w: 1,
+                groups: 1,
+                has_bias: false,
+            },
+            vec![relu],
+            DtypeRepr::F32,
+            shape_1d(4),
+        );
+        g.add_node(Op::Sigmoid, vec![conv], DtypeRepr::F32, shape_1d(4));
+
+        let fused = g.fuse_elementwise_chains();
+
+        // Conv2d isn't fusable, so it blocks fusion on both sides: Relu can't fuse
+        // forward into Conv2d, and Sigmoid can't fuse backward past it either.
+        assert_eq!(fused.nodes.len(), 4);
+        assert!(matches!(fused.nodes[1].op, Op::Relu));
+        assert!(matches!(fused.nodes[2].op, Op::Conv2d { .. }));
+        assert!(matches!(fused.nodes[3].op, Op::Sigmoid));
+    }
+
+    #[test]
+    fn test_fuse_elementwise_chains_no_fusion_when_multiple_consumers() {
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(4));
+        let relu = g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(4));
+        // Two consumers of `relu` — it can't be absorbed into either chain since
+        // something else still needs its standalone output.
+        g.add_node(Op::Sigmoid, vec![relu], DtypeRepr::F32, shape_1d(4));
+        g.add_node(Op::Silu, vec![relu], DtypeRepr::F32, shape_1d(4));
+
+        let fused = g.fuse_elementwise_chains();
+
+        assert_eq!(fused.nodes.len(), 4);
+        assert!(matches!(fused.nodes[1].op, Op::Relu));
+        assert!(matches!(fused.nodes[2].op, Op::Sigmoid));
+        assert!(matches!(fused.nodes[3].op, Op::Silu));
+    }
+
+    #[test]
+    fn test_fuse_elementwise_chains_rewires_downstream_consumer() {
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(4));
+        let relu = g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(4));
+        let sigmoid = g.add_node(Op::Sigmoid, vec![relu], DtypeRepr::F32, shape_1d(4));
+        // A non-fusable consumer downstream of the chain must end up pointing at
+        // the new Fused node's index, not a dangling/stale one.
+        g.add_node(
+            Op::Conv2d {
+                in_channels: 4,
+                out_channels: 4,
+                kernel_h: 1,
+                kernel_w: 1,
+                stride_h: 1,
+                stride_w: 1,
+                padding_h: 0,
+                padding_w: 0,
+                groups: 1,
+                has_bias: false,
+            },
+            vec![sigmoid],
+            DtypeRepr::F32,
+            shape_1d(4),
+        );
+
+        let fused = g.fuse_elementwise_chains();
+
+        assert_eq!(fused.nodes.len(), 3);
+        let fused_idx = 1;
+        assert!(matches!(fused.nodes[fused_idx].op, Op::Fused { .. }));
+        assert_eq!(fused.nodes[2].inputs, vec![fused_idx]);
+    }
+
+    #[test]
+    fn test_fuse_elementwise_chains_grows_past_two_via_fixed_point() {
+        // Four fusable ops in a row: a single fuse_elementwise_chain_pass() call only
+        // merges one adjacent pair, so this only ends up as one node if the fixed-point
+        // loop in fuse_elementwise_chains() actually keeps iterating.
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(4));
+        let relu = g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(4));
+        let sigmoid = g.add_node(Op::Sigmoid, vec![relu], DtypeRepr::F32, shape_1d(4));
+        let silu = g.add_node(Op::Silu, vec![sigmoid], DtypeRepr::F32, shape_1d(4));
+        g.add_node(Op::Tanh, vec![silu], DtypeRepr::F32, shape_1d(4));
+
+        let fused = g.fuse_elementwise_chains();
+
+        assert_eq!(fused.nodes.len(), 2);
+        match &fused.nodes[1].op {
+            Op::Fused { members } => {
+                assert_eq!(members.len(), 4);
+                assert!(matches!(members[0], Op::Relu));
+                assert!(matches!(members[1], Op::Sigmoid));
+                assert!(matches!(members[2], Op::Silu));
+                assert!(matches!(members[3], Op::Tanh));
+            }
+            other => panic!("expected Op::Fused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_optimise_does_not_produce_fused_nodes() {
+        // optimise() must keep behaving exactly as it did before Op::Fused existed —
+        // fuse_elementwise_chains() is opt-in precisely so existing optimise() callers
+        // aren't handed a node type their lowering backend doesn't know how to compile.
+        let mut g = Graph::new();
+        let input = g.add_node(Op::Input, vec![], DtypeRepr::F32, shape_1d(4));
+        let relu = g.add_node(Op::Relu, vec![input], DtypeRepr::F32, shape_1d(4));
+        g.add_node(Op::Sigmoid, vec![relu], DtypeRepr::F32, shape_1d(4));
+
+        let optimised = g.optimise();
+
+        assert_eq!(optimised.nodes.len(), 3);
+        for node in &optimised.nodes {
+            assert!(!matches!(node.op, Op::Fused { .. }));
+        }
     }
 }

--- a/kernels/teeny-kernels/src/graph/mod.rs
+++ b/kernels/teeny-kernels/src/graph/mod.rs
@@ -2765,6 +2765,20 @@ impl TritonLowering {
                         ));
                     }
                 },
+
+                Op::Fused { members } => {
+                    // Graph::fuse_elementwise_chains() (teeny-core) is opt-in and not
+                    // called by optimise(), specifically because lowering here doesn't
+                    // exist yet — see that method's doc comment. A graph only reaches
+                    // this arm if a caller explicitly asked for elementwise fusion
+                    // without yet having a backend that can compile the result.
+                    return Err(anyhow::anyhow!(
+                        "Op::Fused lowering is not implemented yet ({} member op(s)): \
+                         concatenate each member's kernel source and synthesize an \
+                         entry point that runs them in sequence (see spinorml-1fj.1)",
+                        members.len()
+                    ));
+                }
             };
 
             let dag_idx = dag.add_node(executable);


### PR DESCRIPTION
## Summary
- Generalizes the existing Conv2d→BN→Silu fusion precedent into a reusable mechanism: `Op::Fused{members}` holds an arbitrary run of adjacent, single-input/single-output elementwise ops.
- `Graph::fuse_elementwise_chains()` detects them via a conservative allowlist (`Relu`/`Sigmoid`/`Silu`/`Tanh` — chosen because they share one fixed elementwise CTA/thread structure, so no `RuntimeOp` lookup is needed at this point in the pipeline) plus the existing single-consumer eligibility check, iterated to a fixed point so chains longer than two nodes fuse fully.
- Deliberately **not** wired into `optimise()`: `teeny-kernels`' lowering doesn't yet know how to compile `Op::Fused` (kernel-source concatenation + a synthesized entry point is the next step), so folding this in would hand every existing `optimise()` caller a node type their backend can't lower. `teeny-kernels`' dispatch match gets an explicit `Op::Fused` arm returning a clear "not implemented yet" error instead.

See spinorml-1fj.1 for the fuller design writeup and Phase 2 (kernel-source concatenation) follow-up plan.

## Test plan
- [x] 10 new unit tests (chain fusion, single-consumer exclusion, non-fusable ops blocking the chain on both sides, downstream-consumer rewiring, fixed-point growth past 2 members, and a regression guard proving `optimise()` itself is unchanged)
- [x] Full workspace test suite green
- [x] clippy clean