### PR TITLE
perf(kernels): pick GEMM tile size (BLOCK_M/N/K) per shape

### DIFF
--- a/kernels/teeny-kernels/src/graph/mod.rs
+++ b/kernels/teeny-kernels/src/graph/mod.rs
@@ -597,6 +597,95 @@ mod pick_adaptive_block_n_tests {
     }
 }
 
+/// Picks (BLOCK_M, BLOCK_N, BLOCK_K) for a GEMM of shape `[M, K] @ [K, N] -> [M, N]`
+/// based on its size, instead of one fixed tile size for every shape.
+///
+/// Per spinorml-4gx's ONNX Runtime profile, cuDNN/CUTLASS auto-tunes tile size per
+/// layer rather than using one fixed configuration — seven distinct configs were
+/// observed in active use for one model (64x64_16, 128x64_16, 256x64_16, 128x128_16,
+/// 256x128_16, 64x128_32, in `BLOCK_M x BLOCK_N _ BLOCK_K` terms). This mirrors that
+/// spirit with a small fixed table rather than the exact tuned values, which are
+/// specific to CUTLASS's own kernel templates:
+///
+/// - BLOCK_K grows with `k` (more reduction work amortizes each K-tile's load cost;
+///   a small `k` gets a small BLOCK_K instead of wasting shared memory tiling past
+///   the reduction dimension's actual extent). Never below 8: `T::dot`'s TF32 tensor
+///   core path needs at least that much K per MMA tile.
+/// - BLOCK_M/BLOCK_N grow with `m`/`n` for the same reason (bigger output tiles only
+///   pay off once there's enough output to fill many CTAs at that size; small outputs
+///   get finer tiles instead, for occupancy).
+///
+/// `m` is `None` when the batch dimension is dynamic (unknown at lowering time) — it's
+/// treated as small (64) rather than guessed large, so an unexpectedly small runtime
+/// batch doesn't end up under-occupied at a tile size chosen for a batch that never
+/// materializes. This under-estimates for large dynamic batches the same way
+/// `pick_adaptive_block_n`'s batch-omitted `fixed_blocks` does — see its doc comment.
+fn pick_gemm_tile_sizes(m: Option<usize>, n: usize, k: usize) -> (i32, i32, i32) {
+    let m = m.unwrap_or(64);
+    let block_k = if k >= 128 {
+        32
+    } else if k >= 32 {
+        16
+    } else {
+        8
+    };
+    let (block_m, block_n) = match (m, n) {
+        (m, n) if m >= 256 && n >= 128 => (256, 128),
+        (m, n) if m >= 128 && n >= 128 => (128, 128),
+        (m, _) if m >= 128 => (128, 64),
+        (_, n) if n >= 128 => (64, 128),
+        _ => (64, 64),
+    };
+    (block_m, block_n, block_k)
+}
+
+#[cfg(test)]
+mod pick_gemm_tile_sizes_tests {
+    use super::pick_gemm_tile_sizes;
+
+    #[test]
+    fn small_shape_gets_smallest_tiles() {
+        assert_eq!(pick_gemm_tile_sizes(Some(64), 64, 16), (64, 64, 8));
+    }
+
+    #[test]
+    fn large_m_and_n_get_the_largest_tile() {
+        assert_eq!(pick_gemm_tile_sizes(Some(512), 256, 256), (256, 128, 32));
+    }
+
+    #[test]
+    fn large_m_only_widens_block_m_not_block_n() {
+        assert_eq!(pick_gemm_tile_sizes(Some(512), 32, 64), (128, 64, 16));
+    }
+
+    #[test]
+    fn large_n_only_widens_block_n_not_block_m() {
+        assert_eq!(pick_gemm_tile_sizes(Some(32), 512, 64), (64, 128, 16));
+    }
+
+    #[test]
+    fn unknown_dynamic_batch_treated_as_small() {
+        // m=None should behave the same as an explicit small m, not a large one.
+        assert_eq!(
+            pick_gemm_tile_sizes(None, 64, 16),
+            pick_gemm_tile_sizes(Some(64), 64, 16)
+        );
+    }
+
+    #[test]
+    fn block_k_never_drops_below_the_tensor_core_minimum() {
+        let (_, _, block_k) = pick_gemm_tile_sizes(Some(64), 64, 1);
+        assert!(block_k >= 8);
+    }
+
+    #[test]
+    fn block_k_grows_with_k() {
+        assert_eq!(pick_gemm_tile_sizes(Some(64), 64, 8).2, 8);
+        assert_eq!(pick_gemm_tile_sizes(Some(64), 64, 32).2, 16);
+        assert_eq!(pick_gemm_tile_sizes(Some(64), 64, 128).2, 32);
+    }
+}
+
 impl TritonLowering {
     /// Like `lower` but also returns the graph-node-index → DAG-node-index mapping.
     /// Useful for middleware lowerings that need to patch specific DAG nodes after
@@ -1182,28 +1271,33 @@ impl TritonLowering {
                     let use_tiled = !is_depthwise && g == 1 && c_out >= 16 && !use_gemm;
 
                     if use_gemm {
-                        const BLOCK_M: i32 = 32;
-                        const BLOCK_N: i32 = 32;
-                        const BLOCK_K: i32 = 32;
                         const GROUP_M: i32 = 8;
+                        let m = oh * ow;
+                        // Shape-appropriate starting tile size (spinorml-4gx.2) — see
+                        // pick_gemm_tile_sizes' doc comment. m is always statically known
+                        // here (derived from the conv's own OH/OW), unlike the general
+                        // MatMul case, so it's passed as Some rather than treated as dynamic.
+                        let (block_m, block_n_base, block_k) =
+                            pick_gemm_tile_sizes(Some(m), c_out, *in_channels);
                         // BLOCK_N also sets this kernel's shared-memory-per-block footprint,
                         // so shrinking it for occupancy-starved shapes helps twice over: more
                         // blocks *and* a higher occupancy ceiling (shared mem is the binding
-                        // occupancy limiter for this kernel at the default tile size).
+                        // occupancy limiter for this kernel at the default tile size). This
+                        // is a separate, hardware-occupancy-driven adjustment layered on top
+                        // of the shape-driven starting point above, not a replacement for it.
                         let block_n = match self.sm_count {
                             Some(sm_count) => {
-                                let m = oh * ow;
-                                let fixed_blocks = m.div_ceil(BLOCK_M as usize);
+                                let fixed_blocks = m.div_ceil(block_m as usize);
                                 pick_adaptive_block_n(
                                     c_out,
                                     fixed_blocks,
                                     4 * sm_count,
-                                    &[BLOCK_N, 16, 8],
+                                    &[block_n_base, 16, 8],
                                 )
                             }
-                            None => BLOCK_N,
+                            None => block_n_base,
                         };
-                        let k = Conv2dBnSiluGemmForward::new(BLOCK_M, block_n, BLOCK_K, GROUP_M);
+                        let k = Conv2dBnSiluGemmForward::new(block_m, block_n, block_k, GROUP_M);
                         let nm = k.name.to_string();
                         let ks = k.source.clone();
                         let rop: Arc<dyn RuntimeOp> = Arc::new(k);
@@ -2357,9 +2451,19 @@ impl TritonLowering {
 
                 // ── Matrix ops ────────────────────────────────────────────────
                 Op::MatMul | Op::Gemm { .. } => {
+                    // A: [M, K], B: [K, N], C (output): [M, N].
+                    let m = node.shape.first().copied().flatten();
+                    let n = node.shape.last().copied().flatten().unwrap_or(0);
+                    let k = node
+                        .inputs
+                        .first()
+                        .and_then(|&i| graph.nodes[i].shape.last().copied().flatten())
+                        .unwrap_or(0);
+                    let (block_m, block_n, block_k) = pick_gemm_tile_sizes(m, n, k);
+
                     let (name, ks, rop): (String, String, Arc<dyn RuntimeOp>) = match node.dtype {
                         DtypeRepr::F32 => {
-                            let r = MatMulRuntimeOp::<f32>::new(128);
+                            let r = MatMulRuntimeOp::<f32>::new(block_m, block_n, block_k);
                             (
                                 r.kernel_name().to_string(),
                                 r.forward_source().to_string(),
@@ -2367,7 +2471,7 @@ impl TritonLowering {
                             )
                         }
                         DtypeRepr::F64 => {
-                            let r = MatMulRuntimeOp::<f64>::new(128);
+                            let r = MatMulRuntimeOp::<f64>::new(block_m, block_n, block_k);
                             (
                                 r.kernel_name().to_string(),
                                 r.forward_source().to_string(),

--- a/kernels/teeny-kernels/src/math/gemm.rs
+++ b/kernels/teeny-kernels/src/math/gemm.rs
@@ -236,12 +236,11 @@ pub struct MatMulRuntimeOp<D: Num + Send + Sync + 'static> {
 }
 
 impl<D: Num + Send + Sync + 'static> MatMulRuntimeOp<D> {
-    /// `block_size` is used as BLOCK_M, BLOCK_N, and BLOCK_K alike.
-    pub fn new(block_size: i32) -> Self {
+    pub fn new(block_m: i32, block_n: i32, block_k: i32) -> Self {
         Self {
-            fwd_kernel: MatmulForward::<D>::new(block_size, block_size, block_size, GROUP_M),
-            bwd_da_kernel: MatmulBackwardDa::<D>::new(block_size, block_size, block_size, GROUP_M),
-            bwd_db_kernel: MatmulBackwardDb::<D>::new(block_size, block_size, block_size, GROUP_M),
+            fwd_kernel: MatmulForward::<D>::new(block_m, block_n, block_k, GROUP_M),
+            bwd_da_kernel: MatmulBackwardDa::<D>::new(block_m, block_n, block_k, GROUP_M),
+            bwd_db_kernel: MatmulBackwardDb::<D>::new(block_m, block_n, block_k, GROUP_M),
         }
     }
 

--- a/kernels/teeny-kernels/tests/snapshots/test_conv2d_bn_silu_gemm__test_conv2d_bn_silu_gemm__gemm_forward_source.snap
+++ b/kernels/teeny-kernels/tests/snapshots/test_conv2d_bn_silu_gemm__test_conv2d_bn_silu_gemm__gemm_forward_source.snap
@@ -65,5 +65,5 @@ pub extern "C" fn conv2d_bn_silu_gemm_forward_entry_point(x_ptr: *mut f32, w_ptr
     let bn_scale_ptr = LlvmPointer(bn_scale_ptr as *mut _);
     let bn_shift_ptr = LlvmPointer(bn_shift_ptr as *mut _);
     let y_ptr = LlvmPointer(y_ptr as *mut _);
-    conv2d_bn_silu_gemm_forward::<LlvmTriton, 32, 32, 32, 8>(x_ptr, w_ptr, bn_scale_ptr, bn_shift_ptr, y_ptr, B, C_IN, C_OUT, M);
+    conv2d_bn_silu_gemm_forward::<LlvmTriton, 64, 64, 16, 8>(x_ptr, w_ptr, bn_scale_ptr, bn_shift_ptr, y_ptr, B, C_IN, C_OUT, M);
 }

--- a/kernels/teeny-kernels/tests/test_gemm.rs
+++ b/kernels/teeny-kernels/tests/test_gemm.rs
@@ -431,3 +431,71 @@ fn test_matmul_backward_db_gpu() -> Result<()> {
     }
     Ok(())
 }
+
+// ── Per-shape tile selection (spinorml-4gx.2) ─────────────────────────────────
+//
+// MatmulForward/MatmulBackwardDa/MatmulBackwardDb above are always exercised at a
+// fixed BLOCK_M/N/K, independent of graph lowering. These two tests instead go
+// through TritonLowering, the same path a real model uses, to confirm
+// Op::MatMul's dispatch actually asks pick_gemm_tile_sizes for a shape-appropriate
+// tile size rather than a single hardcoded one.
+
+fn build_matmul_graph(m: usize, k: usize, n: usize) -> teeny_core::graph::Graph {
+    use teeny_core::graph::{DtypeRepr, Op, SymTensor};
+
+    let (a, graph_rc) = SymTensor::input(DtypeRepr::F32, vec![Some(m), Some(k)]);
+    let b_id = a.graph.borrow_mut().add_node(
+        Op::Input,
+        vec![],
+        DtypeRepr::F32,
+        vec![Some(k), Some(n)],
+    );
+    let _ = a.graph.borrow_mut().add_node(
+        Op::MatMul,
+        vec![a.node_id, b_id],
+        DtypeRepr::F32,
+        vec![Some(m), Some(n)],
+    );
+    drop(a);
+    std::rc::Rc::try_unwrap(graph_rc).ok().unwrap().into_inner()
+}
+
+fn lowered_matmul_source(m: usize, k: usize, n: usize) -> String {
+    use teeny_core::model::LoweringMode;
+    use teeny_kernels::graph::TritonLowering;
+
+    let graph = build_matmul_graph(m, k, n);
+    let lowering = TritonLowering::new();
+    let (dag, _) = lowering
+        .lower_with_mapping(&graph, LoweringMode::Inference)
+        .expect("lowering");
+    // Nodes: [a (Input), b (Input), matmul] -> matmul is index 2.
+    dag.node(2).value.forward_kernel_source().to_string()
+}
+
+#[test]
+fn test_matmul_lowering_picks_small_tile_for_small_shape() {
+    let src = lowered_matmul_source(64, 16, 64);
+    assert!(
+        src.contains("LlvmTriton, f32, 64, 64, 8, 8"),
+        "expected a 64x64x8 tile for a small (64,16,64) shape, got: {src}"
+    );
+}
+
+#[test]
+fn test_matmul_lowering_picks_larger_tile_for_large_shape() {
+    let src = lowered_matmul_source(512, 256, 256);
+    assert!(
+        src.contains("LlvmTriton, f32, 256, 128, 32"),
+        "expected a 256x128x32 tile for a large (512,256,256) shape, got: {src}"
+    );
+}
+
+#[test]
+fn test_matmul_lowering_differs_by_shape() {
+    // The actual point of this task: two different shapes must not collapse to the
+    // same hardcoded tile size.
+    let small = lowered_matmul_source(64, 16, 64);
+    let large = lowered_matmul_source(512, 256, 256);
+    assert_ne!(small, large);
+}


### PR DESCRIPTION
## Summary
- Adds `pick_gemm_tile_sizes(m, n, k)`, a small fixed table (in the spirit of the existing `pick_adaptive_block_n`) that grows BLOCK_M/BLOCK_N with output size and BLOCK_K with the reduction dimension, instead of one hardcoded tile size for every GEMM shape.
- Matches cuDNN/CUTLASS's own per-shape tile auto-tuning observed in an ONNX Runtime profile (spinorml-4gx).
- Wires it into both GEMM dispatch sites: `Op::MatMul`/`Op::Gemm` (`gemm.rs`, `MatMulRuntimeOp::new` now takes `block_m`/`block_n`/`block_k` instead of one `block_size`), and `Conv2dBnSilu`'s 1×1-conv GEMM path, where it layers underneath the existing `sm_count`-driven occupancy adjustment (`pick_adaptive_block_n`) rather than replacing it.
- BLOCK_K never drops below 8 — `T::dot`'s TF32 tensor-core minimum.

See spinorml-4gx.2.

## Test plan
- [x] 7 unit tests for `pick_gemm_tile_sizes` itself
- [x] 3 integration tests proving different shapes get different tiles end-to-end through `TritonLowering`
- [x] Full workspace test suite green (one known cache-race flake in `test_gemm`, confirmed unrelated by rerunning alone)
- [x] clippy clean