### PR TITLE
perf(kernels): fuse Conv2d+bias into one kernel for inference

### DIFF
--- a/kernels/teeny-kernels/src/graph/mod.rs
+++ b/kernels/teeny-kernels/src/graph/mod.rs
@@ -52,7 +52,7 @@ use crate::nn::{
     },
     conv::{
         conv1d::Conv1dForward,
-        conv2d::{Conv2dBackward, Conv2dForward},
+        conv2d::{Conv2dBackward, Conv2dBiasForward, Conv2dForward},
         conv3d::Conv3dForward,
     },
     fused::{
@@ -741,7 +741,83 @@ impl TritonLowering {
                 continue;
             }
 
-            // Conv2d with bias → split into Conv2d (weight only) + NchwBiasAdd (bias only).
+            // Conv2d with bias, inference mode → one fused conv2d_bias_forward kernel
+            // instead of two separate launches (spinorml-ia5). conv2d_bias_forward has
+            // no backward pass, so training still takes the split path below.
+            if mode == LoweringMode::Inference
+                && let Op::Conv2d {
+                    has_bias: true,
+                    kernel_h,
+                    kernel_w,
+                    stride_h,
+                    stride_w,
+                    padding_h,
+                    padding_w,
+                    groups,
+                    ..
+                } = &node.op
+            {
+                let (name, ks, rop): (String, String, Arc<dyn RuntimeOp>) = match node.dtype {
+                    DtypeRepr::F32 => {
+                        let k = Conv2dBiasForward::<f32>::new(
+                            *kernel_h as i32,
+                            *kernel_w as i32,
+                            *stride_h as i32,
+                            *stride_w as i32,
+                            *padding_h as i32,
+                            *padding_w as i32,
+                            *groups as i32,
+                            16,
+                        );
+                        let nm = k.name.to_string();
+                        let src = k.source.clone();
+                        let rop: Arc<dyn RuntimeOp> = Arc::new(k);
+                        (nm, src, rop)
+                    }
+                    DtypeRepr::F64 => {
+                        let k = Conv2dBiasForward::<f64>::new(
+                            *kernel_h as i32,
+                            *kernel_w as i32,
+                            *stride_h as i32,
+                            *stride_w as i32,
+                            *padding_h as i32,
+                            *padding_w as i32,
+                            *groups as i32,
+                            16,
+                        );
+                        let nm = k.name.to_string();
+                        let src = k.source.clone();
+                        let rop: Arc<dyn RuntimeOp> = Arc::new(k);
+                        (nm, src, rop)
+                    }
+                    other => {
+                        return Err(anyhow::anyhow!(
+                            "{:?} is not supported for Conv2dBiasForward",
+                            other
+                        ));
+                    }
+                };
+                let dag_idx = dag.add_node(Box::new(KernelExecutable {
+                    entry_point: format!("{}_entry_point", name),
+                    name,
+                    kernel_source: ks,
+                    shape: node.shape.clone(),
+                    dtype: node.dtype,
+                    #[cfg(feature = "training")]
+                    backward_kernel_source: String::new(),
+                    #[cfg(feature = "training")]
+                    backward_entry_point: String::new(),
+                    runtime_op: rop,
+                }) as Box<dyn ExecutableOp>);
+                for &input_graph_idx in &node.inputs {
+                    dag.add_edge(graph_to_dag[input_graph_idx], dag_idx);
+                }
+                graph_to_dag[node_index] = dag_idx;
+                continue;
+            }
+
+            // Conv2d with bias (training mode) → split into Conv2d (weight only) +
+            // NchwBiasAdd (bias only), since each needs its own backward kernel.
             if let Op::Conv2d {
                 has_bias: true,
                 kernel_h,

--- a/kernels/teeny-kernels/src/nn/conv/conv2d.rs
+++ b/kernels/teeny-kernels/src/nn/conv/conv2d.rs
@@ -632,3 +632,198 @@ pub struct Conv2dOp<'a, T: Num> {
     pub backward_dw: Conv2dBackwardDw<T>,
     _marker: core::marker::PhantomData<&'a ()>,
 }
+
+/// 2-D convolution forward pass fused with a per-output-channel bias add.
+///
+/// Identical to [`conv2d_forward`] (same grid, same masked-load accumulation loop —
+/// see its doc comment) with one addition: `acc + bias[c_out]` before the store.
+/// `bias` broadcasts the same "load as a [1] tensor, then broadcast_to" pattern
+/// `conv2d_forward` already uses for weights, applied once after the loop instead
+/// of once per (c_in, kh, kw) tap.
+///
+/// For `Conv2d(has_bias=true)` with no downstream BatchNorm/SiLU to fuse into (the
+/// `conv2d_bn_silu` family), this replaces what would otherwise lower to two
+/// separate kernel launches — [`conv2d_forward`] then a standalone NCHW bias-add —
+/// with one. See spinorml-ia5.
+///
+/// Inference-only; no backward pass (training still uses the two-kernel path via
+/// `conv2d_forward` + a separate bias-add, whose backward is a plain per-channel sum
+/// over the output gradient — fusing that isn't this kernel's job).
+#[kernel]
+pub fn conv2d_bias_forward<
+    T: Triton,
+    D: Num,
+    const KH: i32,
+    const KW: i32,
+    const STRIDE_H: i32,
+    const STRIDE_W: i32,
+    const PAD_H: i32,
+    const PAD_W: i32,
+    const G: i32,
+    const BLOCK_OW: i32,
+>(
+    x_ptr: T::Pointer<D>,
+    w_ptr: T::Pointer<D>,
+    bias_ptr: T::Pointer<D>,
+    y_ptr: T::Pointer<D>,
+    _B: i32,
+    C_IN: i32,
+    C_OUT: i32,
+    H: i32,
+    W: i32,
+    OH: i32,
+    OW: i32,
+) where
+    T::I32Tensor: Tensor<i32, 1>,
+    T::I32Tensor: Comparison<i32, BoolTensor = T::BoolTensor>,
+    T::BoolTensor: BitAnd<Output = T::BoolTensor>,
+    T::Pointer<D>: AddOffsets<i32, 1, T::I32Tensor, Output = T::Tensor<T::Pointer<D>>>,
+{
+    let pid = T::program_id(Axis::X);
+    let num_ow_tiles = T::cdiv(OW, BLOCK_OW);
+
+    let ow_tile = pid % num_ow_tiles;
+    let bco = pid / num_ow_tiles;
+    let oh = bco % OH;
+    let bc = bco / OH;
+    let c_out = bc % C_OUT;
+    let b = bc / C_OUT;
+
+    let ow_start = ow_tile * BLOCK_OW;
+    let ow_range = T::arange(0, BLOCK_OW) + ow_start;
+    let ow_mask = ow_range.lt(OW);
+
+    let out_bc_base = (b * C_OUT + c_out) * OH * OW;
+
+    let c_in_per_group = C_IN / G;
+    let g_idx = c_out / (C_OUT / G);
+    let c_in_start = g_idx * c_in_per_group;
+
+    let mut acc = T::zeros::<D>(&[BLOCK_OW]);
+
+    let loop_bound = c_in_per_group * KH * KW;
+    for idx in 0..loop_bound {
+        let kw = idx % KW;
+        let kh_cin = idx / KW;
+        let kh = kh_cin % KH;
+        let c_in_local = kh_cin / KH;
+        let c_in = c_in_start + c_in_local;
+
+        let ih = oh * STRIDE_H + kh - PAD_H;
+        let iw_range = ow_range * STRIDE_W + kw - PAD_W;
+
+        #[allow(clippy::erasing_op)]
+        let ih_t = ow_range * 0 + ih;
+        let h_in_bounds = ih_t.ge(0) & ih_t.lt(H);
+        let w_in_bounds = iw_range.ge(0) & iw_range.lt(W);
+        let load_mask = ow_mask & h_in_bounds & w_in_bounds;
+
+        let x_offsets = iw_range + ((b * C_IN + c_in) * H * W + ih * W);
+        let x_tile = T::load(
+            x_ptr.add_offsets(x_offsets),
+            Some(load_mask),
+            Some(T::zeros::<D>(&[BLOCK_OW])),
+            &[],
+            None,
+            None,
+            None,
+            false,
+        );
+
+        let w_idx = ((c_out * c_in_per_group + c_in_local) * KH + kh) * KW + kw;
+        let w_off = T::arange(0, 1) + w_idx;
+        let w_1 = T::load(
+            w_ptr.add_offsets(w_off),
+            None,
+            None,
+            &[],
+            None,
+            None,
+            None,
+            false,
+        );
+        let w_tile = T::broadcast_to(w_1, &[BLOCK_OW]);
+
+        acc = acc + x_tile * w_tile;
+    }
+
+    // ── Bias epilog ──────────────────────────────────────────────────────────
+    let bias_off = T::arange(0, 1) + c_out;
+    let bias_1 = T::load(
+        bias_ptr.add_offsets(bias_off),
+        None,
+        None,
+        &[],
+        None,
+        None,
+        None,
+        false,
+    );
+    let bias_tile = T::broadcast_to(bias_1, &[BLOCK_OW]);
+    acc = acc + bias_tile;
+
+    let out_offsets = ow_range + (out_bc_base + oh * OW);
+    T::store(
+        y_ptr.add_offsets(out_offsets),
+        acc,
+        Some(ow_mask),
+        &[],
+        None,
+        None,
+    );
+}
+
+impl<D: Num + Send + Sync + 'static> teeny_core::model::RuntimeOp for Conv2dBiasForward<D> {
+    fn n_activation_inputs(&self) -> usize {
+        1
+    }
+
+    fn param_shapes(&self, input_shapes: &[&[usize]], output_shape: &[usize]) -> Vec<Vec<usize>> {
+        let c_in = input_shapes[0][1];
+        let c_out = output_shape[1];
+        vec![
+            vec![c_out, c_in / self.g as usize, self.kh as usize, self.kw as usize],
+            vec![c_out],
+        ]
+    }
+
+    fn param_names(&self) -> &'static [&'static str] {
+        &["weight", "bias"]
+    }
+
+    fn pack_args(
+        &self,
+        inputs: &[(teeny_core::model::RawPtr, &[usize])],
+        params: &[teeny_core::model::RawPtr],
+        output: teeny_core::model::RawPtr,
+        output_shape: &[usize],
+        _output_row_stride: i32,
+        visitor: &mut dyn teeny_core::device::program::ArgVisitor,
+    ) {
+        let input_shape = inputs[0].1;
+        visitor.visit_ptr(inputs[0].0); // x_ptr
+        visitor.visit_ptr(params[0]); // w_ptr
+        visitor.visit_ptr(params[1]); // bias_ptr
+        visitor.visit_ptr(output); // y_ptr
+        visitor.visit_i32(input_shape[0] as i32); // B
+        visitor.visit_i32(input_shape[1] as i32); // C_IN
+        visitor.visit_i32(output_shape[1] as i32); // C_OUT
+        visitor.visit_i32(input_shape[2] as i32); // H
+        visitor.visit_i32(input_shape[3] as i32); // W
+        visitor.visit_i32(output_shape[2] as i32); // OH
+        visitor.visit_i32(output_shape[3] as i32); // OW
+    }
+
+    fn block(&self) -> [u32; 3] {
+        [128, 1, 1]
+    }
+
+    fn grid(&self, output_shape: &[usize]) -> [u32; 3] {
+        let num_ow_tiles = output_shape[3].div_ceil(self.block_ow as usize);
+        [
+            (output_shape[0] * output_shape[1] * output_shape[2] * num_ow_tiles) as u32,
+            1,
+            1,
+        ]
+    }
+}

--- a/kernels/teeny-kernels/tests/test_conv2d_bias.rs
+++ b/kernels/teeny-kernels/tests/test_conv2d_bias.rs
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Tests for `conv2d_bias_forward` — a Conv2d + per-channel bias fused into one
+//! kernel launch, used (in inference mode) instead of a separate Conv2d + NCHW
+//! bias-add pair. See spinorml-ia5.
+
+use std::rc::Rc;
+
+use teeny_core::{
+    graph::{DtypeRepr, Graph, Op, SymTensor},
+    model::LoweringMode,
+};
+use teeny_kernels::graph::TritonLowering;
+
+#[cfg(feature = "cuda")]
+use dotenv::dotenv;
+#[cfg(feature = "cuda")]
+use teeny_compiler::compiler::{driver::cuda::compile_kernel, target::cuda::Target};
+#[cfg(feature = "cuda")]
+use teeny_core::device::{Device, buffer::Buffer};
+#[cfg(feature = "cuda")]
+use teeny_cuda::{device::CudaLaunchConfig, errors::Result, testing};
+
+const NB: usize = 1;
+const C_IN: usize = 3;
+const C_OUT: usize = 4;
+const HH: usize = 9;
+const WW: usize = 9;
+const KH: i32 = 3;
+const KW: i32 = 3;
+const STRIDE_H: i32 = 1;
+const STRIDE_W: i32 = 1;
+const PAD_H: i32 = 1;
+const PAD_W: i32 = 1;
+const BLOCK_OW: i32 = 16;
+const OH: usize = (HH + 2 * PAD_H as usize - KH as usize) / STRIDE_H as usize + 1; // 9
+const OW: usize = (WW + 2 * PAD_W as usize - KW as usize) / STRIDE_W as usize + 1; // 9
+
+fn build_conv2d_bias_graph() -> Graph {
+    let (input, graph_rc) = SymTensor::input(
+        DtypeRepr::F32,
+        vec![Some(NB), Some(C_IN), Some(HH), Some(WW)],
+    );
+    let out_shape = vec![Some(NB), Some(C_OUT), Some(OH), Some(OW)];
+    let _ = input.graph.borrow_mut().add_node(
+        Op::Conv2d {
+            in_channels: C_IN,
+            out_channels: C_OUT,
+            kernel_h: KH as usize,
+            kernel_w: KW as usize,
+            stride_h: STRIDE_H as usize,
+            stride_w: STRIDE_W as usize,
+            padding_h: PAD_H as usize,
+            padding_w: PAD_W as usize,
+            groups: 1,
+            has_bias: true,
+        },
+        vec![input.node_id],
+        DtypeRepr::F32,
+        out_shape,
+    );
+    drop(input);
+    Rc::try_unwrap(graph_rc).ok().unwrap().into_inner()
+}
+
+#[test]
+fn test_conv2d_bias_inference_lowers_to_one_fused_kernel() {
+    let graph = build_conv2d_bias_graph();
+    let lowering = TritonLowering::new();
+    let (dag, _) = lowering
+        .lower_with_mapping(&graph, LoweringMode::Inference)
+        .expect("lowering");
+
+    // Input + one fused conv2d_bias node — not split into conv + bias-add.
+    assert_eq!(dag.len(), 2);
+    assert!(
+        dag.node(1).value.name().contains("conv2d_bias_forward"),
+        "expected conv2d_bias_forward kernel name, got: {}",
+        dag.node(1).value.name()
+    );
+}
+
+#[test]
+#[cfg(feature = "training")]
+fn test_conv2d_bias_training_still_splits_into_two_kernels() {
+    // conv2d_bias_forward has no backward pass, so training must keep using the
+    // existing Conv2d + NchwBiasAdd split (each has its own backward kernel).
+    let graph = build_conv2d_bias_graph();
+    let lowering = TritonLowering::new();
+    let (dag, _) = lowering
+        .lower_with_mapping(&graph, LoweringMode::Training)
+        .expect("lowering");
+
+    // Input + Conv2d(no bias) + NchwBiasAdd = 3 nodes.
+    assert_eq!(dag.len(), 3);
+    assert!(!dag.node(1).value.name().contains("conv2d_bias_forward"));
+}
+
+#[cfg(feature = "cuda")]
+fn conv2d_bias_reference(
+    x: &[f32],
+    w: &[f32],
+    bias: &[f32],
+    b: usize,
+    c_in: usize,
+    c_out: usize,
+    h: usize,
+    w_sz: usize,
+    kh: usize,
+    kw: usize,
+    pad_h: usize,
+    pad_w: usize,
+    oh: usize,
+    ow: usize,
+) -> Vec<f32> {
+    let mut y = vec![0.0f32; b * c_out * oh * ow];
+    for bi in 0..b {
+        for co in 0..c_out {
+            for ohi in 0..oh {
+                for owi in 0..ow {
+                    let mut acc = bias[co];
+                    for ci in 0..c_in {
+                        for khi in 0..kh {
+                            for kwi in 0..kw {
+                                let ih = (ohi + khi) as isize - pad_h as isize;
+                                let iw = (owi + kwi) as isize - pad_w as isize;
+                                if ih >= 0 && ih < h as isize && iw >= 0 && iw < w_sz as isize {
+                                    let xi =
+                                        ((bi * c_in + ci) * h + ih as usize) * w_sz + iw as usize;
+                                    let wi = ((co * c_in + ci) * kh + khi) * kw + kwi;
+                                    acc += x[xi] * w[wi];
+                                }
+                            }
+                        }
+                    }
+                    y[((bi * c_out + co) * oh + ohi) * ow + owi] = acc;
+                }
+            }
+        }
+    }
+    y
+}
+
+#[test]
+#[cfg(feature = "cuda")]
+fn test_conv2d_bias_forward_matches_reference() -> Result<()> {
+    dotenv().ok();
+    let env = testing::setup_cuda_env()?;
+    let device = env.device;
+
+    let x_host: Vec<f32> = (0..NB * C_IN * HH * WW)
+        .map(|i| (i as f32 % 17.0 - 8.0) * 0.1)
+        .collect();
+    let w_host: Vec<f32> = (0..C_OUT * C_IN * KH as usize * KW as usize)
+        .map(|i| (i as f32 % 13.0 - 6.0) * 0.05)
+        .collect();
+    let bias_host: Vec<f32> = (0..C_OUT).map(|i| i as f32 * 0.1 - 0.2).collect();
+
+    let expected = conv2d_bias_reference(
+        &x_host,
+        &w_host,
+        &bias_host,
+        NB,
+        C_IN,
+        C_OUT,
+        HH,
+        WW,
+        KH as usize,
+        KW as usize,
+        PAD_H as usize,
+        PAD_W as usize,
+        OH,
+        OW,
+    );
+
+    let mut x_buf = device.buffer::<f32>(NB * C_IN * HH * WW)?;
+    let mut w_buf = device.buffer::<f32>(C_OUT * C_IN * KH as usize * KW as usize)?;
+    let mut bias_buf = device.buffer::<f32>(C_OUT)?;
+    let y_buf = device.buffer::<f32>(NB * C_OUT * OH * OW)?;
+
+    x_buf.to_device(&x_host)?;
+    w_buf.to_device(&w_host)?;
+    bias_buf.to_device(&bias_host)?;
+
+    let kernel = teeny_kernels::nn::conv::conv2d::Conv2dBiasForward::<f32>::new(
+        KH, KW, STRIDE_H, STRIDE_W, PAD_H, PAD_W, 1, BLOCK_OW,
+    );
+    let target = Target::new(env.capability);
+    let ptx = std::fs::read(compile_kernel(&kernel, &target, true)?)?;
+    let program = testing::load_program_from_ptx::<
+        teeny_kernels::nn::conv::conv2d::Conv2dBiasForward<f32>,
+    >(&ptx)?;
+
+    let num_ow_tiles = OW.div_ceil(BLOCK_OW as usize);
+    let grid = (NB * C_OUT * OH * num_ow_tiles) as u32;
+    let cfg = CudaLaunchConfig {
+        grid: [grid, 1, 1],
+        block: [128, 1, 1],
+        cluster: [1, 1, 1],
+    };
+
+    device.launch(
+        &program,
+        &cfg,
+        (
+            x_buf.as_device_ptr() as *mut f32,
+            w_buf.as_device_ptr() as *mut f32,
+            bias_buf.as_device_ptr() as *mut f32,
+            y_buf.as_device_ptr() as *mut f32,
+            NB as i32,
+            C_IN as i32,
+            C_OUT as i32,
+            HH as i32,
+            WW as i32,
+            OH as i32,
+            OW as i32,
+        ),
+    )?;
+
+    let mut y_host = vec![0.0f32; NB * C_OUT * OH * OW];
+    y_buf.to_host(&mut y_host)?;
+
+    for i in 0..NB * C_OUT * OH * OW {
+        assert!(
+            (y_host[i] - expected[i]).abs() < 1e-4,
+            "conv2d_bias_forward mismatch at {i}: gpu={} expected={}",
+            y_host[i],
+            expected[i]
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Adds `conv2d_bias_forward`: the same masked-load direct-conv structure as `conv2d_forward`, with a per-output-channel bias add folded into the epilogue instead of left for a separate kernel.
- Per spinorml-ia5, 30/460 kernel calls in a traced YOLO26 inference (19.4% of compute) were plain `Conv2d(has_bias=true)` with no downstream BatchNorm/SiLU to fuse into via the existing `conv2d_bn_silu` family — these were lowering to two launches (Conv2d, then a standalone NCHW bias-add) where one now suffices.
- Wired in for `LoweringMode::Inference` only: `conv2d_bias_forward` has no backward pass, so training keeps the existing two-kernel split (each half needs its own backward kernel).

See spinorml-ia5.

## Test plan
- [x] GPU correctness test against a CPU reference (passing on an RTX 5070)
- [x] Lowering test confirming inference mode produces one dag node instead of two
- [x] Regression-guard test confirming training mode is unchanged
- [x] Full workspace test suite green
- [x] clippy clean