### PR TITLE
fix(tests): update MNIST DAG node count for fused Conv2d+bias

### DIFF
--- a/models/teeny-vision/tests/test_mnist_compile.rs
+++ b/models/teeny-vision/tests/test_mnist_compile.rs
@@ -66,15 +66,16 @@ fn test_mnist_graph_compiles() -> anyhow::Result<()> {
     // Every node except the Input placeholder must have a non-empty ptx_path
     // pointing to a file that actually exists on disk.
     //
-    // The DAG has 2 more nodes than the traced graph: TritonLowering splits
-    // each biased Conv2d into a bias-free Conv2dForward kernel plus a
-    // separate NchwBiasAddRuntimeOp node, and LeNet-5 has two biased Conv2d
-    // layers.
+    // In LoweringMode::Inference, TritonLowering lowers each biased Conv2d to a
+    // single fused conv2d_bias_forward kernel (spinorml-ia5) rather than
+    // splitting it into a bias-free Conv2dForward kernel plus a separate
+    // NchwBiasAddRuntimeOp node, so the DAG has the same node count as the
+    // traced graph — no extra splitting nodes.
     let dag = &model.dag;
     assert_eq!(
         dag.len(),
-        16,
-        "compiled DAG should have 2 extra nodes from Conv2d bias-add splitting"
+        graph.nodes.len(),
+        "compiled DAG should have no extra nodes: inference-mode Conv2d+bias fuses into one kernel"
     );
 
     let topo = dag.topological_sort();
@@ -99,8 +100,9 @@ fn test_mnist_graph_compiles() -> anyhow::Result<()> {
     }
 
     assert_eq!(
-        compiled_count, 15,
-        "expected 15 compiled kernels (all ops except Input, including split bias-adds)"
+        compiled_count,
+        graph.nodes.len() - 1,
+        "expected one compiled kernel per traced op (all nodes except Input)"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
Found while running the full workspace suite after merging #19, #20, #21 together — this test wasn't part of any of those three PRs' own test runs, so it slipped through.

`#21` made inference-mode `Conv2d(has_bias=true)` lower to a single fused `conv2d_bias_forward` kernel instead of splitting into a bias-free `Conv2dForward` + a separate `NchwBiasAdd` node. `test_mnist_graph_compiles` hardcoded the old split-node counts (16 DAG nodes, 15 compiled kernels) for LeNet-5's two biased Conv2d layers. Updated the assertions to be relative to `graph.nodes.len()` instead of literals, so this can't silently drift again if the traced graph shape changes.

## Test plan
- [x] `test_mnist_graph_compiles` passes
- [x] Full workspace test suite green (one known cache-race flake in `test_groupnorm`, confirmed unrelated by rerunning alone)