### PR TITLE
fix: reject dtype-mismatched and bool-terminal-violating pointwise fusions

### DIFF
--- a/kernels/teeny-kernels/src/graph/optimizer/anduin.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/anduin.rs
@@ -21,7 +21,9 @@ use teeny_triton::PointwiseFuseProbe;
 
 use crate::errors::Result;
 use crate::graph::optimizer::GraphOptimizer;
-use crate::graph::optimizer::ops::{PointwiseFuse, probe_pointwise_op};
+use crate::graph::optimizer::ops::{
+    PointwiseFuse, is_bool_terminal_only, is_pointwise_fuse_dtype, probe_pointwise_op,
+};
 
 /// Anduin: Triton-side graph rewrites before lowering.
 ///
@@ -104,6 +106,14 @@ fn fuse_pointwise_chain_pass(graph: &Graph) -> (Graph, bool) {
         }
 
         let parent_dtype = graph.nodes[parent_idx].dtype;
+        // A fused chain lowers every member through one shared dtype
+        // (PointwiseFuse::dtype); parent and child must already agree, and
+        // that dtype must be one PointwiseFuse can actually emit -- otherwise
+        // this either silently drops the parent's real dtype or panics later
+        // in PointwiseFuse::lower() on an unsupported dtype.
+        if parent_dtype != child_dtype || !is_pointwise_fuse_dtype(child_dtype) {
+            continue;
+        }
         let Some((mut members, parent_probe)) =
             pointwise_parts(&graph.nodes[parent_idx].op, parent_dtype)
         else {
@@ -115,6 +125,15 @@ fn fuse_pointwise_chain_pass(graph: &Graph) -> (Graph, bool) {
         // Append child's members (single op or an existing PointwiseFuse).
         members.extend(child_members);
         if members.len() < 2 {
+            continue;
+        }
+        // Bool-producing ops (IsNaN, IsInf) change the element type mid-chain;
+        // a later member reading their output as the chain's float dtype
+        // would be wrong, so they may only be the chain's last member.
+        if members[..members.len() - 1]
+            .iter()
+            .any(is_bool_terminal_only)
+        {
             continue;
         }
 

--- a/kernels/teeny-kernels/src/graph/optimizer/ops/mod.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/ops/mod.rs
@@ -18,4 +18,6 @@
 
 mod pointwise_fuse;
 
-pub use pointwise_fuse::{PointwiseFuse, probe_pointwise_op};
+pub use pointwise_fuse::{
+    PointwiseFuse, is_bool_terminal_only, is_pointwise_fuse_dtype, probe_pointwise_op,
+};

--- a/kernels/teeny-kernels/src/graph/optimizer/ops/pointwise_fuse.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/ops/pointwise_fuse.rs
@@ -53,6 +53,21 @@ pub fn probe_pointwise_op(op: &Op, dtype: DtypeRepr) -> Option<PointwiseFuseProb
     }
 }
 
+/// True when `dtype` is one [`PointwiseFuse::lower`] can actually emit (see
+/// [`dtype_name`]). Callers building a chain must check this before fusing --
+/// [`dtype_name`] itself only runs at lower time, which is too late to refuse
+/// gracefully.
+pub fn is_pointwise_fuse_dtype(dtype: DtypeRepr) -> bool {
+    dtype_name(dtype).is_ok()
+}
+
+/// True when `op`'s output dtype (`bool`) differs from the float dtype
+/// threaded through a chain's scratch buffers, so it may only be the last
+/// member of a [`PointwiseFuse`] chain -- never a value a later member reads.
+pub fn is_bool_terminal_only(op: &Op) -> bool {
+    matches!(op, Op::IsNaN | Op::IsInf { .. })
+}
+
 /// Fused linear chain of unary pointwise activations.
 ///
 /// Produced by Anduin; lowered by concatenating each member's `#[kernel]` body
@@ -575,4 +590,28 @@ fn synthesize_backward_entry(
         params = params,
         body = body,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pointwise_fuse_dtype_accepts_only_float() {
+        assert!(is_pointwise_fuse_dtype(DtypeRepr::F32));
+        assert!(is_pointwise_fuse_dtype(DtypeRepr::F64));
+        assert!(!is_pointwise_fuse_dtype(DtypeRepr::I32));
+        assert!(!is_pointwise_fuse_dtype(DtypeRepr::Bool));
+    }
+
+    #[test]
+    fn bool_terminal_only_flags_isnan_and_isinf() {
+        assert!(is_bool_terminal_only(&Op::IsNaN));
+        assert!(is_bool_terminal_only(&Op::IsInf {
+            detect_negative: true,
+            detect_positive: true,
+        }));
+        assert!(!is_bool_terminal_only(&Op::Relu));
+        assert!(!is_bool_terminal_only(&Op::Sign));
+    }
 }

--- a/kernels/teeny-kernels/tests/test_anduin_pointwise.rs
+++ b/kernels/teeny-kernels/tests/test_anduin_pointwise.rs
@@ -99,6 +99,84 @@ fn build_relu_sigmoid_tanh_graph() -> Graph {
     Rc::try_unwrap(graph_rc).ok().unwrap().into_inner()
 }
 
+/// Two `Neg` nodes chained, with each node's own dtype set independently
+/// (rather than both following the input) so mixed/unsupported-dtype
+/// scenarios can be built without a real dtype-changing op.
+fn build_neg_neg_graph(dtype0: DtypeRepr, dtype1: DtypeRepr) -> Graph {
+    let (input, graph_rc) = SymTensor::input(dtype0, shape_1d(N));
+    let neg0 = input
+        .graph
+        .borrow_mut()
+        .add_node(Op::Neg, vec![input.node_id], dtype0, shape_1d(N));
+    let _ = input
+        .graph
+        .borrow_mut()
+        .add_node(Op::Neg, vec![neg0], dtype1, shape_1d(N));
+    drop(input);
+    Rc::try_unwrap(graph_rc).ok().unwrap().into_inner()
+}
+
+fn build_isnan_isnan_graph() -> Graph {
+    let (input, graph_rc) = SymTensor::input(DtypeRepr::F32, shape_1d(N));
+    let isnan0 = input.graph.borrow_mut().add_node(
+        Op::IsNaN,
+        vec![input.node_id],
+        DtypeRepr::Bool,
+        shape_1d(N),
+    );
+    let _ =
+        input
+            .graph
+            .borrow_mut()
+            .add_node(Op::IsNaN, vec![isnan0], DtypeRepr::Bool, shape_1d(N));
+    drop(input);
+    Rc::try_unwrap(graph_rc).ok().unwrap().into_inner()
+}
+
+fn assert_no_fusion(graph: &Graph) {
+    let opt = Anduin.optimize(graph).unwrap();
+    assert_eq!(
+        opt.nodes.len(),
+        graph.nodes.len(),
+        "expected no fusion, got {opt:?}"
+    );
+    for node in &opt.nodes {
+        if let Op::Custom { data } = &node.op {
+            assert!(
+                data.downcast_ref::<PointwiseFuse>().is_none(),
+                "expected no PointwiseFuse, got {node:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_anduin_does_not_fuse_mixed_dtype_chain() {
+    // Neg(f32) -> Neg(f64): parent/child disagree on dtype.
+    let graph = build_neg_neg_graph(DtypeRepr::F32, DtypeRepr::F64);
+    assert_eq!(graph.nodes.len(), 3);
+    assert_no_fusion(&graph);
+}
+
+#[test]
+fn test_anduin_does_not_fuse_int_dtype_chain() {
+    // Neg(i32) -> Neg(i32): dtype-consistent but not a dtype PointwiseFuse
+    // can lower (dtype_name only accepts f32/f64) -- must not fuse, and
+    // must not panic (PointwiseFuse::lower is never reached).
+    let graph = build_neg_neg_graph(DtypeRepr::I32, DtypeRepr::I32);
+    assert_eq!(graph.nodes.len(), 3);
+    assert_no_fusion(&graph);
+}
+
+#[test]
+fn test_anduin_does_not_fuse_isnan_mid_chain() {
+    // IsNaN -> IsNaN: the first IsNaN would be an interior member if this
+    // fused; bool-producing ops may only ever be a chain's terminal member.
+    let graph = build_isnan_isnan_graph();
+    assert_eq!(graph.nodes.len(), 3);
+    assert_no_fusion(&graph);
+}
+
 fn pointwise_fuse_from(graph: &Graph) -> PointwiseFuse {
     let opt = Anduin.optimize(graph).unwrap();
     match &opt.nodes.last().unwrap().op {


### PR DESCRIPTION
## Summary
- `fuse_pointwise_chain_pass()` fused adjacent pointwise ops without checking they share a dtype `PointwiseFuse` can actually lower, so a dtype-consistent-but-unsupported chain (e.g. `Abs(i32) -> Neg(i32)`) would fuse successfully at graph-optimization time and then panic in `PointwiseFuse::lower()` instead of failing gracefully.
- Bool-producing ops (`IsNaN`, `IsInf`) had nothing stopping them from being placed as an interior (non-terminal) chain member, even though their output dtype diverges from the float dtype threaded through the chain's scratch buffers.
- Adds `is_pointwise_fuse_dtype()` and `is_bool_terminal_only()` guards in `pointwise_fuse.rs`, wired into `anduin.rs`'s fusion pass, so both cases are excluded at graph-optimization time.

Closes teenygrad-1bf.1.2.

## Test plan
- [x] `cargo build -p teeny-kernels`
- [x] `./scripts/test.sh -p teeny-kernels` — all `teeny-kernels` tests pass, including 2 new unit tests (`is_pointwise_fuse_dtype`, `is_bool_terminal_only`) and 3 new integration tests (mixed-dtype chain doesn't fuse, int-dtype chain doesn't fuse/panic, IsNaN mid-chain doesn't fuse)
- [x] `cargo clippy -p teeny-kernels --lib --tests -- -D warnings` — no findings in touched files
- [x] `cargo fmt -p teeny-kernels -- --check`
- Pre-existing `test_avgpool1d` snapshot failures (nondeterministic mangled symbol names, teenygrad-3kb) reproduced identically with these changes stashed — unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)