### PR TITLE
fix(cuda): raise dynamic shared carveout; pad GEMM TMA row strides

### DIFF
--- a/core/teeny-core/src/graph/mod.rs
+++ b/core/teeny-core/src/graph/mod.rs
@@ -1927,10 +1927,8 @@ impl Graph {
             members.push(self.nodes[child_idx].op.clone());
 
             dead[parent_idx] = true;
-            node_override[child_idx] = Some((
-                Op::Fused { members },
-                self.nodes[parent_idx].inputs.clone(),
-            ));
+            node_override[child_idx] =
+                Some((Op::Fused { members }, self.nodes[parent_idx].inputs.clone()));
             changed = true;
         }
 
@@ -1990,10 +1988,7 @@ impl Graph {
 /// of their `RuntimeOp` impls are unimplemented stubs today, and some aren't the plain
 /// fixed-block-size elementwise shape this allowlist is scoped to.
 pub fn is_fusable_elementwise(op: &Op) -> bool {
-    matches!(
-        op,
-        Op::Relu | Op::Sigmoid | Op::Silu | Op::Tanh
-    )
+    matches!(op, Op::Relu | Op::Sigmoid | Op::Silu | Op::Tanh)
 }
 
 // ---------------------------------------------------------------------------
@@ -2013,11 +2008,9 @@ fn infer_output_shape(op: &Op, inputs: &[&Shape]) -> Shape {
     match op {
         Op::Input => input.clone(),
 
-        Op::Fused { members } => members
-            .iter()
-            .fold(input.clone(), |shape, member| {
-                infer_output_shape(member, &[&shape])
-            }),
+        Op::Fused { members } => members.iter().fold(input.clone(), |shape, member| {
+            infer_output_shape(member, &[&shape])
+        }),
 
         // Element-wise / shape-preserving — output shape = input shape
         Op::Relu

--- a/core/teeny-core/src/model/mod.rs
+++ b/core/teeny-core/src/model/mod.rs
@@ -84,9 +84,21 @@ pub trait RuntimeOp: Send + Sync {
 
     /// Returns the required row stride (in elements) for the output buffer of
     /// this op's forward kernel.  The default is the natural row-major stride
-    /// (`output_shape[-1]`).  Kernels using TMA must round up to satisfy the
-    /// 16-byte alignment constraint (e.g. 4 elements for f32).
+    /// ([`forward_output_row_elems`]).  Kernels using TMA must round up so a
+    /// full store tile never straddles the next row (e.g. `M` padded to a
+    /// multiple of `BLOCK_M` for GEMM, or `OW` to a multiple of `BLOCK_OW`
+    /// for tiled conv).
     fn forward_output_row_stride(&self, output_shape: &[usize]) -> usize {
+        self.forward_output_row_elems(output_shape)
+    }
+
+    /// Natural (unpadded) length of one output row, in elements.
+    ///
+    /// Used with [`forward_output_row_stride`] to size the TMA padded buffer:
+    /// `n_rows = numel / row_elems`, allocate `n_rows * row_stride`.
+    /// Default: last dimension of `output_shape`. Ops that view the tensor as
+    /// a different 2-D layout (e.g. NCHW → `[C, OH*OW]`) should override.
+    fn forward_output_row_elems(&self, output_shape: &[usize]) -> usize {
         output_shape.last().copied().unwrap_or(1)
     }
 

--- a/drivers/teeny-cuda/src/device/mod.rs
+++ b/drivers/teeny-cuda/src/device/mod.rs
@@ -273,6 +273,36 @@ impl<'a> Drop for CudaDevice<'a> {
     }
 }
 
+impl CudaDevice<'_> {
+    /// Raise the per-function dynamic shared-memory ceiling when Triton asks for
+    /// more than the default 48 KiB carveout.
+    ///
+    /// Without this, `cuLaunchKernel` returns `CUDA_ERROR_INVALID_ARGUMENT` for
+    /// kernels whose `meta:shared` is in (48 KiB, opt-in max] — e.g.
+    /// `conv2d_bn_silu_gemm` at 128×128 tiles (~64 KiB) on sm_120. Tiles that
+    /// still exceed the device opt-in max (~99 KiB on RTX 5070) must be capped
+    /// at compile/dispatch time instead.
+    pub(crate) fn ensure_dynamic_shared(
+        function: cuda::CUfunction,
+        shared_bytes: u32,
+    ) -> Result<()> {
+        if shared_bytes == 0 {
+            return Ok(());
+        }
+        let status = unsafe {
+            cuda::cuFuncSetAttribute(
+                function,
+                cuda::CUfunction_attribute_enum_CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                shared_bytes as i32,
+            )
+        };
+        if status != cuda::cudaError_enum_CUDA_SUCCESS {
+            return Err(Error::from_cuda_error(status).into());
+        }
+        Ok(())
+    }
+}
+
 impl<'a> Device<'a> for CudaDevice<'a> {
     type Buffer<N: Num> = CudaBuffer<'a, N>;
     type Program<K: teeny_core::device::program::Kernel> = CudaProgram<'a, K>;
@@ -313,6 +343,8 @@ impl<'a> Device<'a> for CudaDevice<'a> {
         // Build the pointer array while `packer` is still alive — both must
         // remain live for the entire duration of `cuLaunchKernel`.
         let mut ptrs = packer.as_ptrs();
+
+        Self::ensure_dynamic_shared(program.function, program.metadata.shared)?;
 
         let status = unsafe {
             cuda::cuLaunchKernel(
@@ -367,6 +399,7 @@ impl<'a> CudaDevice<'a> {
         stream: cuda::CUstream,
     ) -> Result<()> {
         let mut ptrs = packer.as_ptrs();
+        Self::ensure_dynamic_shared(program.function, program.metadata.shared)?;
         let status = unsafe {
             cuda::cuLaunchKernel(
                 program.function,
@@ -415,6 +448,8 @@ impl<'a> CudaDevice<'a> {
         packer.visit_ptr(scratch_ptr as *mut std::ffi::c_void);
         packer.visit_ptr(std::ptr::null_mut());
         let mut ptrs = packer.as_ptrs();
+
+        Self::ensure_dynamic_shared(program.function, program.metadata.shared)?;
 
         let status = unsafe {
             cuda::cuLaunchKernel(

--- a/drivers/teeny-cuda/src/model/mod.rs
+++ b/drivers/teeny-cuda/src/model/mod.rs
@@ -575,9 +575,7 @@ impl LoadedModel {
 
             // Some ops (e.g. linear_forward) use TMA and require a row stride that
             // is a multiple of 16 bytes.  Allocate a padded output buffer when needed.
-            let natural_stride = loaded
-                .runtime_op
-                .forward_output_row_elems(&output_shape);
+            let natural_stride = loaded.runtime_op.forward_output_row_elems(&output_shape);
             let required_stride = loaded.runtime_op.forward_output_row_stride(&output_shape);
             let n_rows = output_shape.iter().product::<usize>() / natural_stride.max(1);
 
@@ -756,9 +754,7 @@ impl LoadedModel {
             let out_ptr = mem::alloc(byte_size)?;
 
             // TMA alignment: allocate a padded output buffer when the op requires it.
-            let natural_stride = loaded
-                .runtime_op
-                .forward_output_row_elems(&output_shape);
+            let natural_stride = loaded.runtime_op.forward_output_row_elems(&output_shape);
             let required_stride = loaded.runtime_op.forward_output_row_stride(&output_shape);
             let n_rows = output_shape.iter().product::<usize>() / natural_stride.max(1);
 

--- a/drivers/teeny-cuda/src/model/mod.rs
+++ b/drivers/teeny-cuda/src/model/mod.rs
@@ -575,7 +575,9 @@ impl LoadedModel {
 
             // Some ops (e.g. linear_forward) use TMA and require a row stride that
             // is a multiple of 16 bytes.  Allocate a padded output buffer when needed.
-            let natural_stride = output_shape.last().copied().unwrap_or(1);
+            let natural_stride = loaded
+                .runtime_op
+                .forward_output_row_elems(&output_shape);
             let required_stride = loaded.runtime_op.forward_output_row_stride(&output_shape);
             let n_rows = output_shape.iter().product::<usize>() / natural_stride.max(1);
 
@@ -754,7 +756,9 @@ impl LoadedModel {
             let out_ptr = mem::alloc(byte_size)?;
 
             // TMA alignment: allocate a padded output buffer when the op requires it.
-            let natural_stride = output_shape.last().copied().unwrap_or(1);
+            let natural_stride = loaded
+                .runtime_op
+                .forward_output_row_elems(&output_shape);
             let required_stride = loaded.runtime_op.forward_output_row_stride(&output_shape);
             let n_rows = output_shape.iter().product::<usize>() / natural_stride.max(1);
 
@@ -1308,7 +1312,7 @@ impl LoadedModel {
             node_out_bufs[idx] = out_ptr;
 
             // TMA padded buffer when the op requires a wider row stride.
-            let natural_stride = output_shape.last().copied().unwrap_or(1);
+            let natural_stride = loaded.runtime_op.forward_output_row_elems(output_shape);
             let required_stride = loaded.runtime_op.forward_output_row_stride(output_shape);
             if required_stride > natural_stride {
                 let n_rows = n_elems / natural_stride.max(1);
@@ -1411,7 +1415,11 @@ impl LoadedModel {
                     cuda::cuMemsetD8Async(scratch_ptr, 0, scratch_total as usize, stream)
                 };
                 if s != cuda::cudaError_enum_CUDA_SUCCESS {
-                    capture_err = Some(Error::from_cuda_error(s).into());
+                    capture_err = Some(anyhow::anyhow!(
+                        "capture_graph: scratch memset failed at node {idx} \
+                         (shape={output_shape:?}, scratch_total={scratch_total}): {}",
+                        Error::from_cuda_error(s),
+                    ));
                     break 'capture;
                 }
             }
@@ -1456,7 +1464,13 @@ impl LoadedModel {
                 };
                 if let Err(e) = device.launch_on_stream(&loaded.program, &cfg, &mut packer, stream)
                 {
-                    capture_err = Some(e);
+                    capture_err = Some(anyhow::anyhow!(
+                        "capture_graph: launch failed at node {idx} \
+                         (grid={grid:?}, block={block:?}, cluster={cluster:?}, \
+                         shape={output_shape:?}, row_stride={required_stride}, \
+                         scratch={}): {e:#}",
+                        loaded.program.metadata.global_scratch_size,
+                    ));
                     break 'capture;
                 }
             }
@@ -1478,7 +1492,11 @@ impl LoadedModel {
                 };
                 let s = unsafe { cuda::cuMemcpy2DAsync_v2(&params, stream) };
                 if s != cuda::cudaError_enum_CUDA_SUCCESS {
-                    capture_err = Some(Error::from_cuda_error(s).into());
+                    capture_err = Some(anyhow::anyhow!(
+                        "capture_graph: cuMemcpy2DAsync depad failed at node {idx} \
+                         (ns={ns}, rs={rs}, n_rows={n_rows}, eb={eb}): {}",
+                        Error::from_cuda_error(s),
+                    ));
                     break 'capture;
                 }
             }
@@ -1511,7 +1529,10 @@ impl LoadedModel {
             for &p in &owned {
                 let _ = mem::free(p);
             }
-            return Err(Error::from_cuda_error(end_s).into());
+            return Err(anyhow::anyhow!(
+                "capture_graph: cuStreamEndCapture failed: {}",
+                Error::from_cuda_error(end_s)
+            ));
         }
 
         let mut graph_exec: cuda::CUgraphExec = std::ptr::null_mut();
@@ -1522,7 +1543,10 @@ impl LoadedModel {
             for &p in &owned {
                 let _ = mem::free(p);
             }
-            return Err(Error::from_cuda_error(inst_s).into());
+            return Err(anyhow::anyhow!(
+                "capture_graph: cuGraphInstantiateWithFlags failed: {}",
+                Error::from_cuda_error(inst_s)
+            ));
         }
 
         if output_node_indices.is_empty() {

--- a/kernels/teeny-kernels/benches/conv2d_bn_silu.rs
+++ b/kernels/teeny-kernels/benches/conv2d_bn_silu.rs
@@ -253,6 +253,7 @@ fn bench_gemm(
         "GEMM variant only supports 1x1/stride=1/pad=0 convs"
     );
     let m = shape.hh * shape.ww;
+    let y_row_stride = m.next_multiple_of(BLOCK_M_GEMM as usize);
     let w_host: Vec<f32> = (0..shape.c_out * shape.c_in)
         .map(|i| (i as f32 % 13.0 - 6.0) * 0.05)
         .collect();
@@ -261,7 +262,7 @@ fn bench_gemm(
     let mut w_buf = device.buffer::<f32>(w_host.len())?;
     let mut s_buf = device.buffer::<f32>(shape.c_out)?;
     let mut sh_buf = device.buffer::<f32>(shape.c_out)?;
-    let y_buf = device.buffer::<f32>(shape.nb * shape.c_out * m)?;
+    let y_buf = device.buffer::<f32>(shape.nb * shape.c_out * y_row_stride)?;
 
     x_buf.to_device(&shape.x_host())?;
     w_buf.to_device(&w_host)?;
@@ -298,6 +299,7 @@ fn bench_gemm(
                         shape.c_in as i32,
                         shape.c_out as i32,
                         m as i32,
+                        y_row_stride as i32,
                     ),
                 )
                 .unwrap();

--- a/kernels/teeny-kernels/src/graph/mod.rs
+++ b/kernels/teeny-kernels/src/graph/mod.rs
@@ -629,8 +629,11 @@ fn pick_gemm_tile_sizes(m: Option<usize>, n: usize, k: usize) -> (i32, i32, i32)
     } else {
         8
     };
+    // Capped at 128×128: a 256×128 tile needs ~128 KiB dynamic shared memory,
+    // above the opt-in ceiling on some sm_120 devices (~99 KiB on RTX 5070).
+    // 128×128 (~64 KiB) fits under the per-function opt-in raised via
+    // `cuFuncSetAttribute(MAX_DYNAMIC_SHARED_SIZE_BYTES)` in teeny-cuda's launch path.
     let (block_m, block_n) = match (m, n) {
-        (m, n) if m >= 256 && n >= 128 => (256, 128),
         (m, n) if m >= 128 && n >= 128 => (128, 128),
         (m, _) if m >= 128 => (128, 64),
         (_, n) if n >= 128 => (64, 128),
@@ -650,7 +653,8 @@ mod pick_gemm_tile_sizes_tests {
 
     #[test]
     fn large_m_and_n_get_the_largest_tile() {
-        assert_eq!(pick_gemm_tile_sizes(Some(512), 256, 256), (256, 128, 32));
+        // Largest safe tile: 256×128 would exceed the sm_120 opt-in shared-memory ceiling.
+        assert_eq!(pick_gemm_tile_sizes(Some(512), 256, 256), (128, 128, 32));
     }
 
     #[test]

--- a/kernels/teeny-kernels/src/nn/conv/conv2d.rs
+++ b/kernels/teeny-kernels/src/nn/conv/conv2d.rs
@@ -782,7 +782,12 @@ impl<D: Num + Send + Sync + 'static> teeny_core::model::RuntimeOp for Conv2dBias
         let c_in = input_shapes[0][1];
         let c_out = output_shape[1];
         vec![
-            vec![c_out, c_in / self.g as usize, self.kh as usize, self.kw as usize],
+            vec![
+                c_out,
+                c_in / self.g as usize,
+                self.kh as usize,
+                self.kw as usize,
+            ],
             vec![c_out],
         ]
     }

--- a/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu_gemm.rs
+++ b/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu_gemm.rs
@@ -36,6 +36,12 @@ use teeny_triton::triton::{
 ///
 /// Weight W is [C_OUT, C_IN] row-major.
 ///
+/// Output Y is viewed as [B*C_OUT, y_row_stride] where `y_row_stride >= M` and
+/// `y_row_stride` is a multiple of `BLOCK_M`. TMA stores a full `[BLOCK_N,
+/// BLOCK_M]` tile; without that padding the last M-tile writes past `M` into
+/// the next channel (silent overwrite). Runtime allocates the padded buffer
+/// and depads back to tight NCHW.
+///
 /// T::dot uses TF32 Tensor Cores on sm_87+ (Jetson Orin) for ~8× throughput
 /// vs direct scalar accumulation.
 ///
@@ -67,7 +73,11 @@ pub fn conv2d_bn_silu_gemm_forward<
     B: i32,
     C_IN: i32,
     C_OUT: i32,
-    M: i32, // OH * OW per batch
+    M: i32, // OH * OW per batch (tight spatial extent)
+    // y_row_stride: allocated column width per (b, c_out) row.
+    //   Must satisfy: y_row_stride >= M AND divisible by BLOCK_M.
+    //   Prevents the last M-tile's TMA store from spilling into the next channel.
+    y_row_stride: i32,
 ) where
     T::I32Tensor: Tensor<i32, 1>,
     T::I32Tensor: Comparison<i32, BoolTensor = T::BoolTensor>,
@@ -167,12 +177,13 @@ pub fn conv2d_bn_silu_gemm_forward<
     // ── SiLU epilog: y = x * sigmoid(x) ─────────────────────────────────────
     let y = bn_out * T::sigmoid(bn_out);
 
-    // ── Store: y NCHW [B, C_OUT, OH, OW] viewed as [B*C_OUT, M] ─────────────
-    // y[b, c_out, oh, ow] = y_flat[(b*C_OUT + c_out)*M + oh*OW + ow]
+    // ── Store: y NCHW [B, C_OUT, OH, OW] viewed as [B*C_OUT, y_row_stride] ───
+    // Valid columns are [0, M); columns [M, y_row_stride) are padding so the
+    // last BLOCK_M-wide TMA store cannot spill into the next channel's row.
     let y_desc = T::make_tensor_descriptor(
         y_ptr,
-        &[B * C_OUT, M],
-        &[M, 1],
+        &[B * C_OUT, y_row_stride],
+        &[y_row_stride, 1],
         &[BLOCK_N, BLOCK_M],
         Some(PaddingOption::Zero),
     );
@@ -183,7 +194,7 @@ pub fn conv2d_bn_silu_gemm_forward<
 //
 // Params layout: [weight [C_OUT, C_IN], bn_scale [C_OUT], bn_shift [C_OUT]]
 // pack_args order: x_ptr, w_ptr, bn_scale_ptr, bn_shift_ptr, y_ptr,
-//                  B, C_IN, C_OUT, M (= OH * OW)
+//                  B, C_IN, C_OUT, M (= OH * OW), y_row_stride
 
 impl teeny_core::model::RuntimeOp for Conv2dBnSiluGemmForward {
     fn n_activation_inputs(&self) -> usize {
@@ -201,13 +212,24 @@ impl teeny_core::model::RuntimeOp for Conv2dBnSiluGemmForward {
         &["weight", "bn_scale", "bn_shift"]
     }
 
+    // Row = one (b, c_out) channel flattened over OH*OW. Pad to a multiple of
+    // BLOCK_M so the last TMA store tile stays inside the channel's row.
+    fn forward_output_row_elems(&self, output_shape: &[usize]) -> usize {
+        output_shape[2] * output_shape[3]
+    }
+
+    fn forward_output_row_stride(&self, output_shape: &[usize]) -> usize {
+        let m = self.forward_output_row_elems(output_shape);
+        m.next_multiple_of(self.block_m as usize)
+    }
+
     fn pack_args(
         &self,
         inputs: &[(teeny_core::model::RawPtr, &[usize])],
         params: &[teeny_core::model::RawPtr],
         output: teeny_core::model::RawPtr,
         output_shape: &[usize],
-        _output_row_stride: i32,
+        output_row_stride: i32,
         visitor: &mut dyn teeny_core::device::program::ArgVisitor,
     ) {
         let input_shape = inputs[0].1;
@@ -224,6 +246,7 @@ impl teeny_core::model::RuntimeOp for Conv2dBnSiluGemmForward {
         visitor.visit_i32(c_in);
         visitor.visit_i32(c_out);
         visitor.visit_i32(m);
+        visitor.visit_i32(output_row_stride); // y_row_stride
     }
 
     fn block(&self) -> [u32; 3] {

--- a/kernels/teeny-kernels/tests/snapshots/test_conv2d_bn_silu_gemm__test_conv2d_bn_silu_gemm__gemm_forward_source.snap
+++ b/kernels/teeny-kernels/tests/snapshots/test_conv2d_bn_silu_gemm__test_conv2d_bn_silu_gemm__gemm_forward_source.snap
@@ -6,11 +6,11 @@ pub fn conv2d_bn_silu_gemm_forward < T : Triton, const BLOCK_M : i32, const
 BLOCK_N : i32, const BLOCK_K : i32, const GROUP_M : i32, >
 (x_ptr : T :: Pointer < f32 > , w_ptr : T :: Pointer < f32 > , bn_scale_ptr :
 T :: Pointer < f32 > , bn_shift_ptr : T :: Pointer < f32 > , y_ptr : T ::
-Pointer < f32 > , B : i32, C_IN : i32, C_OUT : i32, M : i32,) where T ::
-I32Tensor : Tensor < i32, 1 > , T :: I32Tensor : Comparison < i32, BoolTensor
-= T :: BoolTensor > , T :: BoolTensor : BitAnd < Output = T :: BoolTensor > ,
-T :: Pointer < f32 > : AddOffsets < i32, 1, T :: I32Tensor, Output = T ::
-Tensor < T :: Pointer < f32 > > > ,
+Pointer < f32 > , B : i32, C_IN : i32, C_OUT : i32, M : i32, y_row_stride :
+i32,) where T :: I32Tensor : Tensor < i32, 1 > , T :: I32Tensor : Comparison <
+i32, BoolTensor = T :: BoolTensor > , T :: BoolTensor : BitAnd < Output = T ::
+BoolTensor > , T :: Pointer < f32 > : AddOffsets < i32, 1, T :: I32Tensor,
+Output = T :: Tensor < T :: Pointer < f32 > > > ,
 {
     let pid = T :: program_id(Axis :: X); let num_pid_m = T ::
     cdiv(M, BLOCK_M); let num_pid_n = T :: cdiv(C_OUT, BLOCK_N); let
@@ -48,8 +48,9 @@ Tensor < T :: Pointer < f32 > > > ,
     broadcast_to(T :: expand_dims(bn_shift, 1), & [BLOCK_N, BLOCK_M]); let
     bn_out = scale_2d * acc + shift_2d; let y = bn_out * T :: sigmoid(bn_out);
     let y_desc = T ::
-    make_tensor_descriptor(y_ptr, & [B * C_OUT, M], & [M, 1], &
-    [BLOCK_N, BLOCK_M], Some(PaddingOption :: Zero),); T ::
+    make_tensor_descriptor(y_ptr, & [B * C_OUT, y_row_stride], &
+    [y_row_stride, 1], & [BLOCK_N, BLOCK_M], Some(PaddingOption :: Zero),); T
+    ::
     store_tensor_descriptor(y_desc, &
     [b * C_OUT + pid_n * BLOCK_N, pid_m * BLOCK_M], y);
 }
@@ -59,11 +60,11 @@ use triton::llvm::triton::pointer::LlvmPointer;
 type LlvmTriton = triton::llvm::triton::LlvmTriton;
 
 #[no_mangle]
-pub extern "C" fn conv2d_bn_silu_gemm_forward_entry_point(x_ptr: *mut f32, w_ptr: *mut f32, bn_scale_ptr: *mut f32, bn_shift_ptr: *mut f32, y_ptr: *mut f32, B: i32, C_IN: i32, C_OUT: i32, M: i32) {
+pub extern "C" fn conv2d_bn_silu_gemm_forward_entry_point(x_ptr: *mut f32, w_ptr: *mut f32, bn_scale_ptr: *mut f32, bn_shift_ptr: *mut f32, y_ptr: *mut f32, B: i32, C_IN: i32, C_OUT: i32, M: i32, y_row_stride: i32) {
     let x_ptr = LlvmPointer(x_ptr as *mut _);
     let w_ptr = LlvmPointer(w_ptr as *mut _);
     let bn_scale_ptr = LlvmPointer(bn_scale_ptr as *mut _);
     let bn_shift_ptr = LlvmPointer(bn_shift_ptr as *mut _);
     let y_ptr = LlvmPointer(y_ptr as *mut _);
-    conv2d_bn_silu_gemm_forward::<LlvmTriton, 64, 64, 16, 8>(x_ptr, w_ptr, bn_scale_ptr, bn_shift_ptr, y_ptr, B, C_IN, C_OUT, M);
+    conv2d_bn_silu_gemm_forward::<LlvmTriton, 64, 64, 16, 8>(x_ptr, w_ptr, bn_scale_ptr, bn_shift_ptr, y_ptr, B, C_IN, C_OUT, M, y_row_stride);
 }

--- a/kernels/teeny-kernels/tests/test_conv2d_bn_silu_gemm.rs
+++ b/kernels/teeny-kernels/tests/test_conv2d_bn_silu_gemm.rs
@@ -227,6 +227,7 @@ fn test_conv2d_bn_silu_gemm_matches_reference() -> Result<()> {
             C_IN as i32,
             C_OUT as i32,
             M as i32,
+            M as i32, // y_row_stride: M is already BLOCK_M-aligned (64 / 32)
         ),
     )?;
     y_buf.to_host(&mut y_gpu)?;
@@ -324,6 +325,7 @@ fn test_conv2d_bn_silu_gemm_c_out32_c_in64_m1600() -> Result<()> {
             C_IN2 as i32,
             C_OUT2 as i32,
             M2 as i32,
+            M2 as i32, // y_row_stride: M2 is already BLOCK_M-aligned (1600 / 32)
         ),
     )?;
     y_buf.to_host(&mut y_gpu)?;

--- a/kernels/teeny-kernels/tests/test_gemm.rs
+++ b/kernels/teeny-kernels/tests/test_gemm.rs
@@ -444,12 +444,10 @@ fn build_matmul_graph(m: usize, k: usize, n: usize) -> teeny_core::graph::Graph 
     use teeny_core::graph::{DtypeRepr, Op, SymTensor};
 
     let (a, graph_rc) = SymTensor::input(DtypeRepr::F32, vec![Some(m), Some(k)]);
-    let b_id = a.graph.borrow_mut().add_node(
-        Op::Input,
-        vec![],
-        DtypeRepr::F32,
-        vec![Some(k), Some(n)],
-    );
+    let b_id =
+        a.graph
+            .borrow_mut()
+            .add_node(Op::Input, vec![], DtypeRepr::F32, vec![Some(k), Some(n)]);
     let _ = a.graph.borrow_mut().add_node(
         Op::MatMul,
         vec![a.node_id, b_id],


### PR DESCRIPTION
## Summary
- `cuLaunchKernel` was returning `CUDA_ERROR_INVALID_VALUE` for any kernel requesting dynamic shared memory above CUDA's default 48 KiB carveout — `teeny-cuda`'s launch path never called `cuFuncSetAttribute(MAX_DYNAMIC_SHARED_SIZE_BYTES)` to opt in. Hit in practice by the `conv2d_bn_silu_gemm` fused kernel's 256×128 GEMM tile (~128 KiB) when running yolo26n end-to-end on an RTX 5070 (sm_120), which also exceeds that device's ~99 KiB opt-in ceiling.
- `CudaDevice::ensure_dynamic_shared` now raises the opt-in ceiling before every launch (`launch`, `launch_on_stream`, `launch_with_packer`), and `pick_gemm_tile_sizes` caps the largest GEMM tile at 128×128 (~64 KiB, fits comfortably under the opt-in ceiling on sm_120).
- Also pads `conv2d_bn_silu_gemm`'s output row stride to a `BLOCK_M` multiple (`forward_output_row_elems`/`forward_output_row_stride`) so a partial last-tile TMA store can't silently overwrite the next channel's row.
- Adds richer error context on `capture_graph` failures (node index/shape/grid/block in the error message) — what made this diagnosable in the first place.

## Test plan
- [x] `cargo test -p teeny-kernels --features cuda` — all `conv2d_bn_silu_gemm` tests pass (2 GPU-execution correctness tests, source snapshot re-blessed); pre-existing unrelated `avgpool1d` snapshot failures confirmed present on `main` too.
- [x] `cargo build -p teeny-cuda -p teeny-kernels -p teeny-core`
- [x] Verified against `vision-rs` via `[patch.crates-io]`: `yolo26 debug-infer`/`bench`/`view` all previously crashed with `CUDA error: 1 (invalid argument)` on RTX 5070; all now run clean end-to-end (bench: 107 img/s @ batch 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)