### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
   "compiler/*"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Teenygrad is a high-performance, memory-safe Rust ML training and inference library. It targets devices from microcontrollers to traditional GPUs with statically-typed kernels and full async support."
@@ -21,14 +21,18 @@ homepage = "https://teenygrad.org"
 readme = "README.md"
 
 [workspace.dependencies]
-teeny-core = { path = "core/teeny-core", version = "0.1.3" }
-teeny-macros = { path = "macros/teeny-macros", version = "0.1.3" }
-teeny-triton = { path = "kernels/teeny-triton", version = "0.1.3" }
-teeny-kernels = { path = "kernels/teeny-kernels", version = "0.1.3" }
-teeny-fxgraph = { path = "support/teeny-fxgraph", version = "0.1.3" }
-teeny-compiler = { path = "compiler/teeny-compiler", version = "0.1.3" }
-teeny-cuda = { path = "drivers/teeny-cuda", version = "0.1.3" }
-teeny-vision = { path = "models/teeny-vision", version = "0.1.3" }
+teeny-core = { path = "core/teeny-core", version = "0.2.0" }
+teeny-macros = { path = "macros/teeny-macros", version = "0.2.0" }
+teeny-triton = { path = "kernels/teeny-triton", version = "0.2.0" }
+teeny-kernels = { path = "kernels/teeny-kernels", version = "0.2.0" }
+# No version requirement: never published (publish = false), workspace-internal only
+# (see support/teeny-torch, its sole consumer). A pinned version here has to be bumped
+# in lockstep with [workspace.package].version or `cargo update` fails to resolve it
+# against itself -- that mismatch is exactly what broke the 0.1.3 -> 0.2.0 bump.
+teeny-fxgraph = { path = "support/teeny-fxgraph" }
+teeny-compiler = { path = "compiler/teeny-compiler", version = "0.2.0" }
+teeny-cuda = { path = "drivers/teeny-cuda", version = "0.2.0" }
+teeny-vision = { path = "models/teeny-vision", version = "0.2.0" }
 
 anyhow = { version = "1.0.100", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }

--- a/utilities/teeny-quant/Cargo.toml
+++ b/utilities/teeny-quant/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 
 [dependencies]
 teeny-core.workspace = true
-teeny-data = { path = "../teeny-data", version = "0.1.3" }
+teeny-data = { path = "../teeny-data", version = "0.2.0" }
 safetensors.workspace = true
 half.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary
Manual version bump — `release-plz`'s automated `release-pr` job failed on this one (see below), so this replaces the stale/outdated #23.

- `[workspace.package].version`: `0.1.3` → `0.2.0`. `teeny-kernels`' `conv2d_bn_silu_gemm_forward` gained a required `y_row_stride` parameter in #33 (public API break), and for a pre-1.0 workspace that means a MINOR bump (0.1.x → 0.2.0) across every crate sharing the workspace version, not a patch release.
- Bumped the matching `version = "..."` requirements in `[workspace.dependencies]`.
- Dropped the `version` requirement on `teeny-fxgraph` (path-only now) — it's `publish = false`/workspace-internal (sole consumer: `teeny-torch`, also `publish = false`), but it still shared the single workspace version like every other crate. Its hardcoded `version = "0.1.3"` self-pin didn't move with the bump, so `cargo update` failed to resolve it against itself once everything else hit `0.2.0` — this is what broke `release-plz`'s own `release-pr` job (see [run](https://github.com/teenygrad/teenygrad/actions/runs/31941072835/job/95148930962)). No version requirement is needed since it's never resolved from a registry.
- Same fix for one other stray hardcoded pin: `teeny-quant` → `teeny-data`.

## Test plan
- [x] `cargo check --workspace` — 0 errors
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --exclude teeny-torch -- -D warnings` (matches CI exactly) — clean

Closes the stale #23 (predates this and two other merged commits; wrong version target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)