### PR TITLE
chore: lowercase teenygrad in copyright headers, add project URL

### DIFF
--- a/compiler/teeny-compiler/src/compiler/backend/llvm/compiler.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/llvm/compiler.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/backend/llvm/mod.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/llvm/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/backend/llvm/module.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/llvm/module.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/backend/mod.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/backend/ndarray/compiler.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/ndarray/compiler.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/backend/ndarray/mod.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/ndarray/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/backend/ndarray/module.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/ndarray/module.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/compiler/mod.rs
+++ b/compiler/teeny-compiler/src/compiler/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/errors.rs
+++ b/compiler/teeny-compiler/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/fxgraph/mod.rs
+++ b/compiler/teeny-compiler/src/fxgraph/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/fxgraph/rules/mod.rs
+++ b/compiler/teeny-compiler/src/fxgraph/rules/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/src/lib.rs
+++ b/compiler/teeny-compiler/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/compiler/teeny-compiler/tests/test_compiler.rs
+++ b/compiler/teeny-compiler/tests/test_compiler.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/compiler/mod.rs
+++ b/core/teeny-core/src/compiler/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/context/buffer.rs
+++ b/core/teeny-core/src/context/buffer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/context/device.rs
+++ b/core/teeny-core/src/context/device.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/context/mod.rs
+++ b/core/teeny-core/src/context/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/context/program.rs
+++ b/core/teeny-core/src/context/program.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/device/buffer.rs
+++ b/core/teeny-core/src/device/buffer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/device/context.rs
+++ b/core/teeny-core/src/device/context.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/device/mod.rs
+++ b/core/teeny-core/src/device/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/device/program.rs
+++ b/core/teeny-core/src/device/program.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/dtype/bytes.rs
+++ b/core/teeny-core/src/dtype/bytes.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/dtype/mod.rs
+++ b/core/teeny-core/src/dtype/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/errors.rs
+++ b/core/teeny-core/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/graph/compiler.rs
+++ b/core/teeny-core/src/graph/compiler.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/graph/mod.rs
+++ b/core/teeny-core/src/graph/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/lib.rs
+++ b/core/teeny-core/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/macros.rs
+++ b/core/teeny-core/src/macros.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/model/mod.rs
+++ b/core/teeny-core/src/model/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/name_scope.rs
+++ b/core/teeny-core/src/name_scope.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/elu.rs
+++ b/core/teeny-core/src/nn/activation/elu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/gelu.rs
+++ b/core/teeny-core/src/nn/activation/gelu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/hard.rs
+++ b/core/teeny-core/src/nn/activation/hard.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/misc.rs
+++ b/core/teeny-core/src/nn/activation/misc.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/mod.rs
+++ b/core/teeny-core/src/nn/activation/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/relu.rs
+++ b/core/teeny-core/src/nn/activation/relu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/sigmoid.rs
+++ b/core/teeny-core/src/nn/activation/sigmoid.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/softmax.rs
+++ b/core/teeny-core/src/nn/activation/softmax.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/activation/tanh.rs
+++ b/core/teeny-core/src/nn/activation/tanh.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/batchnorm.rs
+++ b/core/teeny-core/src/nn/batchnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/conv1d.rs
+++ b/core/teeny-core/src/nn/conv1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/conv2d.rs
+++ b/core/teeny-core/src/nn/conv2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/conv3d.rs
+++ b/core/teeny-core/src/nn/conv3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/flatten.rs
+++ b/core/teeny-core/src/nn/flatten.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/groupnorm.rs
+++ b/core/teeny-core/src/nn/groupnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/instancenorm.rs
+++ b/core/teeny-core/src/nn/instancenorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/layernorm.rs
+++ b/core/teeny-core/src/nn/layernorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/linear.rs
+++ b/core/teeny-core/src/nn/linear.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/mod.rs
+++ b/core/teeny-core/src/nn/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/pad.rs
+++ b/core/teeny-core/src/nn/pad.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/pool.rs
+++ b/core/teeny-core/src/nn/pool.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/nn/rmsnorm.rs
+++ b/core/teeny-core/src/nn/rmsnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/runtime/mod.rs
+++ b/core/teeny-core/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/utils/dag.rs
+++ b/core/teeny-core/src/utils/dag.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/teeny-core/src/utils/mod.rs
+++ b/core/teeny-core/src/utils/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/buffer.rs
+++ b/drivers/teeny-cuda/src/buffer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/compiler/aot.rs
+++ b/drivers/teeny-cuda/src/compiler/aot.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/compiler/driver.rs
+++ b/drivers/teeny-cuda/src/compiler/driver.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/compiler/graph.rs
+++ b/drivers/teeny-cuda/src/compiler/graph.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/compiler/mod.rs
+++ b/drivers/teeny-cuda/src/compiler/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/compiler/options.rs
+++ b/drivers/teeny-cuda/src/compiler/options.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/compiler/target.rs
+++ b/drivers/teeny-cuda/src/compiler/target.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/context.rs
+++ b/drivers/teeny-cuda/src/context.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/cuda.rs
+++ b/drivers/teeny-cuda/src/cuda.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/device/buffer.rs
+++ b/drivers/teeny-cuda/src/device/buffer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/device/context.rs
+++ b/drivers/teeny-cuda/src/device/context.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/device/mem.rs
+++ b/drivers/teeny-cuda/src/device/mem.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/device/mod.rs
+++ b/drivers/teeny-cuda/src/device/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/device/program.rs
+++ b/drivers/teeny-cuda/src/device/program.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/errors.rs
+++ b/drivers/teeny-cuda/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/lib.rs
+++ b/drivers/teeny-cuda/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/mem.rs
+++ b/drivers/teeny-cuda/src/mem.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/model/mod.rs
+++ b/drivers/teeny-cuda/src/model/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/program.rs
+++ b/drivers/teeny-cuda/src/program.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/runtime/mod.rs
+++ b/drivers/teeny-cuda/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/src/testing/mod.rs
+++ b/drivers/teeny-cuda/src/testing/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/tests/test_cuda_graph.rs
+++ b/drivers/teeny-cuda/tests/test_cuda_graph.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/tests/test_elemwise_add.rs
+++ b/drivers/teeny-cuda/tests/test_elemwise_add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/drivers/teeny-cuda/wrapper.h
+++ b/drivers/teeny-cuda/wrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/benches/conv2d_bn_silu.rs
+++ b/kernels/teeny-kernels/benches/conv2d_bn_silu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/errors.rs
+++ b/kernels/teeny-kernels/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/graph/mod.rs
+++ b/kernels/teeny-kernels/src/graph/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/graph/optimizer/anduin.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/anduin.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/graph/optimizer/mod.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/graph/optimizer/ops/mod.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/ops/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/graph/optimizer/ops/pointwise_fuse.rs
+++ b/kernels/teeny-kernels/src/graph/optimizer/ops/pointwise_fuse.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/lib.rs
+++ b/kernels/teeny-kernels/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/math/gemm.rs
+++ b/kernels/teeny-kernels/src/math/gemm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/math/matmul.rs
+++ b/kernels/teeny-kernels/src/math/matmul.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/math/mod.rs
+++ b/kernels/teeny-kernels/src/math/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/elu.rs
+++ b/kernels/teeny-kernels/src/nn/activation/elu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/extra.rs
+++ b/kernels/teeny-kernels/src/nn/activation/extra.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/gelu.rs
+++ b/kernels/teeny-kernels/src/nn/activation/gelu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/hard.rs
+++ b/kernels/teeny-kernels/src/nn/activation/hard.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/misc.rs
+++ b/kernels/teeny-kernels/src/nn/activation/misc.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/mod.rs
+++ b/kernels/teeny-kernels/src/nn/activation/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/relu.rs
+++ b/kernels/teeny-kernels/src/nn/activation/relu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/sigmoid.rs
+++ b/kernels/teeny-kernels/src/nn/activation/sigmoid.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/softmax.rs
+++ b/kernels/teeny-kernels/src/nn/activation/softmax.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/activation/tanh.rs
+++ b/kernels/teeny-kernels/src/nn/activation/tanh.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/attention/flash_attn2.rs
+++ b/kernels/teeny-kernels/src/nn/attention/flash_attn2.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/attention/mod.rs
+++ b/kernels/teeny-kernels/src/nn/attention/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/conv/conv1d.rs
+++ b/kernels/teeny-kernels/src/nn/conv/conv1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/conv/conv2d.rs
+++ b/kernels/teeny-kernels/src/nn/conv/conv2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/conv/conv3d.rs
+++ b/kernels/teeny-kernels/src/nn/conv/conv3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/conv/mod.rs
+++ b/kernels/teeny-kernels/src/nn/conv/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu.rs
+++ b/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu_gemm.rs
+++ b/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu_gemm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu_tiled.rs
+++ b/kernels/teeny-kernels/src/nn/fused/conv2d_bn_silu_tiled.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/fused/mod.rs
+++ b/kernels/teeny-kernels/src/nn/fused/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/loss/bce.rs
+++ b/kernels/teeny-kernels/src/nn/loss/bce.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/loss/elementwise.rs
+++ b/kernels/teeny-kernels/src/nn/loss/elementwise.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/loss/embedding.rs
+++ b/kernels/teeny-kernels/src/nn/loss/embedding.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/loss/mod.rs
+++ b/kernels/teeny-kernels/src/nn/loss/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/loss/nll.rs
+++ b/kernels/teeny-kernels/src/nn/loss/nll.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/loss/ranking.rs
+++ b/kernels/teeny-kernels/src/nn/loss/ranking.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/mlp/flatten.rs
+++ b/kernels/teeny-kernels/src/nn/mlp/flatten.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/mlp/linear.rs
+++ b/kernels/teeny-kernels/src/nn/mlp/linear.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/mlp/mod.rs
+++ b/kernels/teeny-kernels/src/nn/mlp/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/mod.rs
+++ b/kernels/teeny-kernels/src/nn/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/norm/batchnorm.rs
+++ b/kernels/teeny-kernels/src/nn/norm/batchnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/norm/groupnorm.rs
+++ b/kernels/teeny-kernels/src/nn/norm/groupnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/norm/instancenorm.rs
+++ b/kernels/teeny-kernels/src/nn/norm/instancenorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/norm/layernorm.rs
+++ b/kernels/teeny-kernels/src/nn/norm/layernorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/norm/mod.rs
+++ b/kernels/teeny-kernels/src/nn/norm/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/norm/rmsnorm.rs
+++ b/kernels/teeny-kernels/src/nn/norm/rmsnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/adagrad.rs
+++ b/kernels/teeny-kernels/src/nn/optim/adagrad.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/adam.rs
+++ b/kernels/teeny-kernels/src/nn/optim/adam.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/adamax.rs
+++ b/kernels/teeny-kernels/src/nn/optim/adamax.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/asgd.rs
+++ b/kernels/teeny-kernels/src/nn/optim/asgd.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/mod.rs
+++ b/kernels/teeny-kernels/src/nn/optim/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/muon.rs
+++ b/kernels/teeny-kernels/src/nn/optim/muon.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/nadam.rs
+++ b/kernels/teeny-kernels/src/nn/optim/nadam.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/radam.rs
+++ b/kernels/teeny-kernels/src/nn/optim/radam.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/rmsprop.rs
+++ b/kernels/teeny-kernels/src/nn/optim/rmsprop.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/rprop.rs
+++ b/kernels/teeny-kernels/src/nn/optim/rprop.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/optim/sgd.rs
+++ b/kernels/teeny-kernels/src/nn/optim/sgd.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/circular_pad1d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/circular_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/circular_pad2d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/circular_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/circular_pad3d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/circular_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/constant_pad1d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/constant_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/constant_pad2d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/constant_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/constant_pad3d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/constant_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/mod.rs
+++ b/kernels/teeny-kernels/src/nn/pad/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/reflection_pad1d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/reflection_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/reflection_pad2d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/reflection_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/reflection_pad3d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/reflection_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/replication_pad1d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/replication_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/replication_pad2d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/replication_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pad/replication_pad3d.rs
+++ b/kernels/teeny-kernels/src/nn/pad/replication_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/avgpool1d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/avgpool1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/avgpool2d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/avgpool2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/avgpool3d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/avgpool3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/lppool1d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/lppool1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/lppool2d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/lppool2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/lppool3d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/lppool3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/maxpool1d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/maxpool1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/maxpool2d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/maxpool2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/maxpool3d.rs
+++ b/kernels/teeny-kernels/src/nn/pool/maxpool3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/pool/mod.rs
+++ b/kernels/teeny-kernels/src/nn/pool/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/channel_bias_add.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/channel_bias_add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/channel_cat.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/channel_cat.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/channel_chunk.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/channel_chunk.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/elemwise_add.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/elemwise_add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/elemwise_binary.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/elemwise_binary.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/elemwise_unary.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/elemwise_unary.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/mod.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/reduction.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/reduction.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/nn/tensor/upsample_nearest2d.rs
+++ b/kernels/teeny-kernels/src/nn/tensor/upsample_nearest2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/src/testing.rs
+++ b/kernels/teeny-kernels/src/testing.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_anduin_pointwise.rs
+++ b/kernels/teeny-kernels/tests/test_anduin_pointwise.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_attention.rs
+++ b/kernels/teeny-kernels/tests/test_attention.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_avgpool1d.rs
+++ b/kernels/teeny-kernels/tests/test_avgpool1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_avgpool2d.rs
+++ b/kernels/teeny-kernels/tests/test_avgpool2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_avgpool3d.rs
+++ b/kernels/teeny-kernels/tests/test_avgpool3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_batchnorm.rs
+++ b/kernels/teeny-kernels/tests/test_batchnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_channel_bias_add.rs
+++ b/kernels/teeny-kernels/tests/test_channel_bias_add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_channel_cat.rs
+++ b/kernels/teeny-kernels/tests/test_channel_cat.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_channel_chunk.rs
+++ b/kernels/teeny-kernels/tests/test_channel_chunk.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_circular_pad1d.rs
+++ b/kernels/teeny-kernels/tests/test_circular_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_circular_pad2d.rs
+++ b/kernels/teeny-kernels/tests/test_circular_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_circular_pad3d.rs
+++ b/kernels/teeny-kernels/tests/test_circular_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_constant_pad1d.rs
+++ b/kernels/teeny-kernels/tests/test_constant_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_constant_pad2d.rs
+++ b/kernels/teeny-kernels/tests/test_constant_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_constant_pad3d.rs
+++ b/kernels/teeny-kernels/tests/test_constant_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_conv1d.rs
+++ b/kernels/teeny-kernels/tests/test_conv1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_conv2d.rs
+++ b/kernels/teeny-kernels/tests/test_conv2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_conv2d_bias.rs
+++ b/kernels/teeny-kernels/tests/test_conv2d_bias.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_conv3d.rs
+++ b/kernels/teeny-kernels/tests/test_conv3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_elemwise_add.rs
+++ b/kernels/teeny-kernels/tests/test_elemwise_add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_elemwise_binary.rs
+++ b/kernels/teeny-kernels/tests/test_elemwise_binary.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_elemwise_unary.rs
+++ b/kernels/teeny-kernels/tests/test_elemwise_unary.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_elu.rs
+++ b/kernels/teeny-kernels/tests/test_elu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_extra_activations.rs
+++ b/kernels/teeny-kernels/tests/test_extra_activations.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_flash_attn2.rs
+++ b/kernels/teeny-kernels/tests/test_flash_attn2.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_flatten.rs
+++ b/kernels/teeny-kernels/tests/test_flatten.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_gelu.rs
+++ b/kernels/teeny-kernels/tests/test_gelu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_gemm.rs
+++ b/kernels/teeny-kernels/tests/test_gemm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_groupnorm.rs
+++ b/kernels/teeny-kernels/tests/test_groupnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_hard_acts.rs
+++ b/kernels/teeny-kernels/tests/test_hard_acts.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_instancenorm.rs
+++ b/kernels/teeny-kernels/tests/test_instancenorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_layernorm.rs
+++ b/kernels/teeny-kernels/tests/test_layernorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_linear.rs
+++ b/kernels/teeny-kernels/tests/test_linear.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_loss_bce.rs
+++ b/kernels/teeny-kernels/tests/test_loss_bce.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_loss_elementwise.rs
+++ b/kernels/teeny-kernels/tests/test_loss_elementwise.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_loss_embedding.rs
+++ b/kernels/teeny-kernels/tests/test_loss_embedding.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_loss_nll.rs
+++ b/kernels/teeny-kernels/tests/test_loss_nll.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_loss_ranking.rs
+++ b/kernels/teeny-kernels/tests/test_loss_ranking.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_lppool1d.rs
+++ b/kernels/teeny-kernels/tests/test_lppool1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_lppool2d.rs
+++ b/kernels/teeny-kernels/tests/test_lppool2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_lppool3d.rs
+++ b/kernels/teeny-kernels/tests/test_lppool3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_maxpool1d.rs
+++ b/kernels/teeny-kernels/tests/test_maxpool1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_maxpool2d.rs
+++ b/kernels/teeny-kernels/tests/test_maxpool2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_maxpool3d.rs
+++ b/kernels/teeny-kernels/tests/test_maxpool3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_misc_acts.rs
+++ b/kernels/teeny-kernels/tests/test_misc_acts.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_adagrad.rs
+++ b/kernels/teeny-kernels/tests/test_optim_adagrad.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_adam.rs
+++ b/kernels/teeny-kernels/tests/test_optim_adam.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_adamax.rs
+++ b/kernels/teeny-kernels/tests/test_optim_adamax.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_asgd.rs
+++ b/kernels/teeny-kernels/tests/test_optim_asgd.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_muon.rs
+++ b/kernels/teeny-kernels/tests/test_optim_muon.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_nadam.rs
+++ b/kernels/teeny-kernels/tests/test_optim_nadam.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_radam.rs
+++ b/kernels/teeny-kernels/tests/test_optim_radam.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_rmsprop.rs
+++ b/kernels/teeny-kernels/tests/test_optim_rmsprop.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_rprop.rs
+++ b/kernels/teeny-kernels/tests/test_optim_rprop.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_optim_sgd.rs
+++ b/kernels/teeny-kernels/tests/test_optim_sgd.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_reduction.rs
+++ b/kernels/teeny-kernels/tests/test_reduction.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_reflection_pad1d.rs
+++ b/kernels/teeny-kernels/tests/test_reflection_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_reflection_pad2d.rs
+++ b/kernels/teeny-kernels/tests/test_reflection_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_reflection_pad3d.rs
+++ b/kernels/teeny-kernels/tests/test_reflection_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_relu.rs
+++ b/kernels/teeny-kernels/tests/test_relu.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_replication_pad1d.rs
+++ b/kernels/teeny-kernels/tests/test_replication_pad1d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_replication_pad2d.rs
+++ b/kernels/teeny-kernels/tests/test_replication_pad2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_replication_pad3d.rs
+++ b/kernels/teeny-kernels/tests/test_replication_pad3d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_rmsnorm.rs
+++ b/kernels/teeny-kernels/tests/test_rmsnorm.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_sigmoid.rs
+++ b/kernels/teeny-kernels/tests/test_sigmoid.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_softmax.rs
+++ b/kernels/teeny-kernels/tests/test_softmax.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_tanh_acts.rs
+++ b/kernels/teeny-kernels/tests/test_tanh_acts.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-kernels/tests/test_upsample_nearest2d.rs
+++ b/kernels/teeny-kernels/tests/test_upsample_nearest2d.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/build.rs
+++ b/kernels/teeny-triton/build.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/examples/block_size.rs
+++ b/kernels/teeny-triton/examples/block_size.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/examples/coalescing.rs
+++ b/kernels/teeny-triton/examples/coalescing.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/examples/numerics.rs
+++ b/kernels/teeny-triton/examples/numerics.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/examples/vector_add.rs
+++ b/kernels/teeny-triton/examples/vector_add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/error.rs
+++ b/kernels/teeny-triton/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/kernel_io.rs
+++ b/kernels/teeny-triton/src/kernel_io.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/lib.rs
+++ b/kernels/teeny-triton/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/core.rs
+++ b/kernels/teeny-triton/src/triton/llvm/core.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/mod.rs
+++ b/kernels/teeny-triton/src/triton/llvm/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/triton/mod.rs
+++ b/kernels/teeny-triton/src/triton/llvm/triton/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/triton/num.rs
+++ b/kernels/teeny-triton/src/triton/llvm/triton/num.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/triton/pointer.rs
+++ b/kernels/teeny-triton/src/triton/llvm/triton/pointer.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/triton/tensor.rs
+++ b/kernels/teeny-triton/src/triton/llvm/triton/tensor.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/llvm/triton/types.rs
+++ b/kernels/teeny-triton/src/triton/llvm/triton/types.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/mod.rs
+++ b/kernels/teeny-triton/src/triton/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/ptr.rs
+++ b/kernels/teeny-triton/src/triton/ptr.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/src/triton/types.rs
+++ b/kernels/teeny-triton/src/triton/types.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/kernels/teeny-triton/tests/test_kitchen_sink.rs
+++ b/kernels/teeny-triton/tests/test_kitchen_sink.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/macros/teeny-macros/src/lib.rs
+++ b/macros/teeny-macros/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/macros/teeny-macros/src/macros/kernel.rs
+++ b/macros/teeny-macros/src/macros/kernel.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/macros/teeny-macros/src/macros/mod.rs
+++ b/macros/teeny-macros/src/macros/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/macros/teeny-macros/tests/test_kernel.rs
+++ b/macros/teeny-macros/tests/test_kernel.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/examples/autograd_debug.rs
+++ b/models/teeny-vision/examples/autograd_debug.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/examples/mnist.rs
+++ b/models/teeny-vision/examples/mnist.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/src/errors.rs
+++ b/models/teeny-vision/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/src/lib.rs
+++ b/models/teeny-vision/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/src/mnist/dataset.rs
+++ b/models/teeny-vision/src/mnist/dataset.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/src/mnist/mod.rs
+++ b/models/teeny-vision/src/mnist/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/models/teeny-vision/tests/test_mnist_compile.rs
+++ b/models/teeny-vision/tests/test_mnist_compile.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/errors.rs
+++ b/support/teeny-fxgraph/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/analysis.rs
+++ b/support/teeny-fxgraph/src/fxgraph/analysis.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/cat.rs
+++ b/support/teeny-fxgraph/src/fxgraph/cat.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/device.rs
+++ b/support/teeny-fxgraph/src/fxgraph/device.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/dtype.rs
+++ b/support/teeny-fxgraph/src/fxgraph/dtype.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/keyvalue.rs
+++ b/support/teeny-fxgraph/src/fxgraph/keyvalue.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/lang.rs
+++ b/support/teeny-fxgraph/src/fxgraph/lang.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/literal.rs
+++ b/support/teeny-fxgraph/src/fxgraph/literal.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/mod.rs
+++ b/support/teeny-fxgraph/src/fxgraph/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/node.rs
+++ b/support/teeny-fxgraph/src/fxgraph/node.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/placeholder.rs
+++ b/support/teeny-fxgraph/src/fxgraph/placeholder.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/shape.rs
+++ b/support/teeny-fxgraph/src/fxgraph/shape.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/tensor.rs
+++ b/support/teeny-fxgraph/src/fxgraph/tensor.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/torch/add.rs
+++ b/support/teeny-fxgraph/src/fxgraph/torch/add.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/torch/mod.rs
+++ b/support/teeny-fxgraph/src/fxgraph/torch/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/torch/output.rs
+++ b/support/teeny-fxgraph/src/fxgraph/torch/output.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/types/mod.rs
+++ b/support/teeny-fxgraph/src/fxgraph/types/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/types/ty_kwargs.rs
+++ b/support/teeny-fxgraph/src/fxgraph/types/ty_kwargs.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/types/ty_tensor.rs
+++ b/support/teeny-fxgraph/src/fxgraph/types/ty_tensor.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/fxgraph/value.rs
+++ b/support/teeny-fxgraph/src/fxgraph/value.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-fxgraph/src/lib.rs
+++ b/support/teeny-fxgraph/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-onnx/build.rs
+++ b/support/teeny-onnx/build.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-onnx/src/errors.rs
+++ b/support/teeny-onnx/src/errors.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-onnx/src/lib.rs
+++ b/support/teeny-onnx/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-onnx/src/onnx.rs
+++ b/support/teeny-onnx/src/onnx.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-onnx/tests/onnx_read_test.rs
+++ b/support/teeny-onnx/tests/onnx_read_test.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/build.rs
+++ b/support/teeny-torch/build.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/graph.fbs
+++ b/support/teeny-torch/graph.fbs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/__init__.py
+++ b/support/teeny-torch/python/teenygrad/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/atlas/__init__.py
+++ b/support/teeny-torch/python/teenygrad/atlas/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/atlas/module.py
+++ b/support/teeny-torch/python/teenygrad/atlas/module.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/graph/__init__.py
+++ b/support/teeny-torch/python/teenygrad/graph/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/graph/deserialize.py
+++ b/support/teeny-torch/python/teenygrad/graph/deserialize.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/graph/serialize.py
+++ b/support/teeny-torch/python/teenygrad/graph/serialize.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/teenygrad/graph/verify.py
+++ b/support/teeny-torch/python/teenygrad/graph/verify.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/tests/test_integration.py
+++ b/support/teeny-torch/python/tests/test_integration.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/tests/test_qwen3.py
+++ b/support/teeny-torch/python/tests/test_qwen3.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/tests/test_serialization.py
+++ b/support/teeny-torch/python/tests/test_serialization.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/tests/test_simple_classifier.py
+++ b/support/teeny-torch/python/tests/test_simple_classifier.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/python/tests/test_vector_add.py
+++ b/support/teeny-torch/python/tests/test_vector_add.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2026 Teenygrad.
+# Copyright (c) 2026 teenygrad (https://teenygrad.org).
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/atlas/mod.rs
+++ b/support/teeny-torch/src/atlas/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/error.rs
+++ b/support/teeny-torch/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/call_function.rs
+++ b/support/teeny-torch/src/graph/call_function.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/call_method.rs
+++ b/support/teeny-torch/src/graph/call_method.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/dtype.rs
+++ b/support/teeny-torch/src/graph/dtype.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/example_input.rs
+++ b/support/teeny-torch/src/graph/example_input.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/keyvalue.rs
+++ b/support/teeny-torch/src/graph/keyvalue.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/mod.rs
+++ b/support/teeny-torch/src/graph/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/output.rs
+++ b/support/teeny-torch/src/graph/output.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/placeholder.rs
+++ b/support/teeny-torch/src/graph/placeholder.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/shape.rs
+++ b/support/teeny-torch/src/graph/shape.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/symint.rs
+++ b/support/teeny-torch/src/graph/symint.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/graph/value.rs
+++ b/support/teeny-torch/src/graph/value.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/lib.rs
+++ b/support/teeny-torch/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/teeny-torch/src/torch.rs
+++ b/support/teeny-torch/src/torch.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-cli/src/lib.rs
+++ b/utilities/teeny-cli/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-cli/src/main.rs
+++ b/utilities/teeny-cli/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-data/src/dataset/loader.rs
+++ b/utilities/teeny-data/src/dataset/loader.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-data/src/dataset/mod.rs
+++ b/utilities/teeny-data/src/dataset/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-data/src/error.rs
+++ b/utilities/teeny-data/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-data/src/lib.rs
+++ b/utilities/teeny-data/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-data/src/safetensors/mod.rs
+++ b/utilities/teeny-data/src/safetensors/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/cli/inspect.rs
+++ b/utilities/teeny-quant/src/cli/inspect.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/cli/mod.rs
+++ b/utilities/teeny-quant/src/cli/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/cli/quantize.rs
+++ b/utilities/teeny-quant/src/cli/quantize.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/cli/validate.rs
+++ b/utilities/teeny-quant/src/cli/validate.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/error.rs
+++ b/utilities/teeny-quant/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/format.rs
+++ b/utilities/teeny-quant/src/format.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/lib.rs
+++ b/utilities/teeny-quant/src/lib.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/main.rs
+++ b/utilities/teeny-quant/src/main.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/quant/affine.rs
+++ b/utilities/teeny-quant/src/quant/affine.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/quant/fp8.rs
+++ b/utilities/teeny-quant/src/quant/fp8.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/quant/granularity.rs
+++ b/utilities/teeny-quant/src/quant/granularity.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/quant/groups.rs
+++ b/utilities/teeny-quant/src/quant/groups.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/quant/mod.rs
+++ b/utilities/teeny-quant/src/quant/mod.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/quant/pack4.rs
+++ b/utilities/teeny-quant/src/quant/pack4.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/read.rs
+++ b/utilities/teeny-quant/src/read.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/validate.rs
+++ b/utilities/teeny-quant/src/validate.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/src/write.rs
+++ b/utilities/teeny-quant/src/write.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/utilities/teeny-quant/tests/quantize_roundtrip.rs
+++ b/utilities/teeny-quant/tests/quantize_roundtrip.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Teenygrad.
+ * Copyright (c) 2026 teenygrad (https://teenygrad.org).
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Switches `Copyright (c) 2026 Teenygrad.` to `Copyright (c) 2026 teenygrad (https://teenygrad.org).` across every source file's license header.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo fmt --check --all`
- [x] `./scripts/test.sh --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)