### PR TITLE
feat(drivers): add teeny-riscv driver crate scaffold

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,14 @@ teeny-kernels = { path = "kernels/teeny-kernels", version = "0.2.1" }
 teeny-fxgraph = { path = "support/teeny-fxgraph" }
 teeny-compiler = { path = "compiler/teeny-compiler", version = "0.2.1" }
 teeny-cuda = { path = "drivers/teeny-cuda", version = "0.2.1" }
+teeny-riscv = { path = "drivers/teeny-riscv", version = "0.2.1" }
 teeny-vision = { path = "models/teeny-vision", version = "0.2.1" }
 
 anyhow = { version = "1.0.100", default-features = false }
 thiserror = { version = "2.0.18", default-features = false }
 sha2 = { version = "0.11.0", default-features = false }
 fd-lock = "4.0.4"
+libloading = "0.9.0"
 image = { version = "0.25", default-features = false, features = ["png"] }
 safetensors = { version = "0.7" }
 protobuf = "3.7.2"

--- a/compiler/teeny-compiler/src/compiler/backend/llvm/compiler.rs
+++ b/compiler/teeny-compiler/src/compiler/backend/llvm/compiler.rs
@@ -77,6 +77,10 @@ impl std::str::FromStr for LogLevel {
 /// `tracing` target `teenyc`'s MLIR backend logs pipeline-stage IR under; see [`LogLevel`].
 const TEENYC_MLIR_LOG_TARGET: &str = "rustc_codegen_llvm::mlir";
 
+/// Default `--target` triple: NVIDIA GPUs via the MLIR/Triton CUDA backend. See
+/// [`LlvmCompiler::with_target_triple`].
+const DEFAULT_TARGET_TRIPLE: &str = "nvptx64-nvidia-cuda";
+
 /// Compiles kernels by shelling out to the custom `teenyc` compiler (`-Zcodegen-backend=mlir`)
 /// at runtime. See [`crate::compiler::find_teenyc`] for how its path is resolved, and the crate
 /// docs for the `cargo-teeny` setup this requires.
@@ -84,6 +88,7 @@ const TEENYC_MLIR_LOG_TARGET: &str = "rustc_codegen_llvm::mlir";
 pub struct LlvmCompiler {
     teenyc_path: PathBuf,
     cache_dir: PathBuf,
+    target_triple: String,
     target_cpu: Option<String>,
     ptx_version: Option<u32>,
     log_level: Option<LogLevel>,
@@ -132,13 +137,29 @@ impl LlvmCompiler {
         Ok(Self {
             teenyc_path,
             cache_dir,
+            target_triple: DEFAULT_TARGET_TRIPLE.to_string(),
             target_cpu: None,
             ptx_version,
             log_level,
         })
     }
 
-    /// Sets the target GPU architecture (e.g. `sm_90`) passed to `teenyc` as `-Ctarget-cpu`.
+    /// Sets the `--target` triple passed to `teenyc`, selecting which Triton backend (Cuda,
+    /// Riscv) compiles the kernel -- see `rustc_codegen_llvm::mlir::target::resolve` in the
+    /// `teeny` compiler fork. Defaults to `"nvptx64-nvidia-cuda"`.
+    ///
+    /// For RISC-V, use `"riscv64-generic"` together with [`Self::with_target_cpu`] set to a
+    /// chip identifier (e.g. `spacemit-k3`, `generic-rvv1.0`) -- not an LLVM `-mcpu` value; the
+    /// RISC-V path doesn't go through LLVM's RISC-V codegen at all yet, and is currently a stub
+    /// that fails every compile until real Triton RISC-V codegen exists.
+    pub fn with_target_triple(mut self, target_triple: impl Into<String>) -> Self {
+        self.target_triple = target_triple.into();
+        self
+    }
+
+    /// Sets the target CPU/architecture (e.g. `sm_90` for CUDA, `spacemit-k3` for RISC-V)
+    /// passed to `teenyc` as `-Ctarget-cpu`. What values are valid depends on
+    /// [`Self::with_target_triple`]'s backend.
     pub fn with_target_cpu(mut self, cpu: impl Into<String>) -> Self {
         self.target_cpu = Some(cpu.into());
         self
@@ -165,7 +186,9 @@ impl LlvmCompiler {
 impl Compiler for LlvmCompiler {
     fn compile(&self, kernel: &impl Kernel, _target: &impl Target, force: bool) -> Result<String> {
         // Hash the kernel id together with target cpu and ptx version so that
-        // different targets/overrides each get their own cache entry.
+        // different targets/overrides each get their own cache entry. target_cpu's
+        // vocabulary never overlaps between backends (sm_XX for CUDA vs. chip names for
+        // RISC-V), so it alone already disambiguates target_triple too.
         let effective_id = {
             let mut h = Sha256::new();
             h.update(kernel.id().as_bytes());
@@ -230,7 +253,7 @@ impl Compiler for LlvmCompiler {
                     .arg("-Zcodegen-backend=mlir")
                     .arg("--emit=obj")
                     .arg(format!("-o{}", tmp_output_file.display()))
-                    .arg("--target=nvptx64-nvidia-cuda")
+                    .arg(format!("--target={}", self.target_triple))
                     .arg("--crate-type=lib")
                     .arg("-C")
                     .arg("overflow-checks=off")

--- a/drivers/teeny-riscv/Cargo.toml
+++ b/drivers/teeny-riscv/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "teeny-riscv"
+version.workspace = true
+edition.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+homepage.workspace = true
+readme = "README.md"
+documentation = "https://docs.teenygrad.org/api/teenygrad/teeny_riscv/"
+keywords = ["riscv", "cpu", "machine-learning", "kernels"]
+categories = ["hardware-support", "science", "external-ffi-bindings"]
+
+[lib]
+
+[dependencies]
+teeny-core.workspace = true
+teeny-compiler.workspace = true
+thiserror.workspace = true
+anyhow.workspace = true
+libloading.workspace = true
+
+[dev-dependencies]
+teeny-kernels = { path = "../../kernels/teeny-kernels" }
+dotenv.workspace = true

--- a/drivers/teeny-riscv/README.md
+++ b/drivers/teeny-riscv/README.md
@@ -1,0 +1,29 @@
+# teeny-riscv
+
+The RISC-V device backend for [teenygrad](https://teenygrad.org) — Target/Capability types for
+the `mlir`/Triton compiler backend's `riscv64-generic` path, and a `libloading`-based runtime for
+loading a compiled kernel's shared library and calling its exported symbol.
+
+## Status
+
+Early scaffold. The underlying `teeny` compiler fork's RISC-V codegen (`RiscvBackend`) is still a
+stub: every kernel currently compiles to the same placeholder no-argument `void @<name>()`
+function regardless of source, through a real LLVM RISC-V `TargetMachine` and linked into a real
+ELF shared library via `ld.lld`. There is no chip-name-to-LLVM-cpu/feature mapping yet (this
+crate's `Capability` values are accepted by the compiler invocation but not yet honored by
+codegen), and no real MIR/Triton-to-LLVM-IR lowering, so real per-kernel argument passing isn't
+possible yet.
+
+This crate's own tests only exercise that pipeline against the current placeholder kernel:
+compiling it via `LlvmCompiler` with the `riscv64-generic` target, and verifying the output is a
+well-formed RISC-V ELF shared object. Actually `dlopen`/calling the compiled kernel (via
+[`runtime::KernelLibrary`]) requires running on real RISC-V hardware or under RISC-V user-mode
+emulation (e.g. `qemu-riscv64`) — this was verified manually during development but isn't part of
+the automated test suite here, since that requires cross-compiling and running the test binary
+itself for `riscv64gc-unknown-linux-gnu`, not just the kernel.
+
+## Prerequisites
+
+Like `teeny-cuda`, kernel compilation shells out to the `teenyc` compiler at runtime — see
+`teeny-compiler`'s docs for `TEENYC_PATH`/`cargo-teeny` setup. No additional system dependency is
+required to build this crate itself (unlike `teeny-cuda`, there's no CUDA toolkit equivalent).

--- a/drivers/teeny-riscv/src/compiler/mod.rs
+++ b/drivers/teeny-riscv/src/compiler/mod.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// `-C target-cpu` chip identifiers and the [`teeny_core::compiler::Target`] impl for RISC-V.
+pub mod target;
+
+/// `--target` triple `teenyc` uses for the RISC-V backend, set on `LlvmCompiler` via
+/// [`teeny_compiler::compiler::backend::llvm::compiler::LlvmCompiler::with_target_triple`].
+///
+/// A dedicated triple (not one of the general-purpose `riscv64gc-*` targets) that exists purely
+/// to be compiled through the `mlir` codegen backend's RISC-V path -- see
+/// `rustc_target::spec::targets::riscv64_generic` in the `teeny` compiler fork.
+pub const TARGET_TRIPLE: &str = "riscv64-generic";

--- a/drivers/teeny-riscv/src/compiler/target.rs
+++ b/drivers/teeny-riscv/src/compiler/target.rs
@@ -88,9 +88,18 @@ mod tests {
 
     #[test]
     fn accepts_canonical_forms() {
-        assert_eq!("generic-rvv1.0".parse::<Capability>().unwrap(), Capability::GenericRvv1_0);
-        assert_eq!("spacemit-k1".parse::<Capability>().unwrap(), Capability::SpacemitK1);
-        assert_eq!("SPACEMIT-K3".parse::<Capability>().unwrap(), Capability::SpacemitK3);
+        assert_eq!(
+            "generic-rvv1.0".parse::<Capability>().unwrap(),
+            Capability::GenericRvv1_0
+        );
+        assert_eq!(
+            "spacemit-k1".parse::<Capability>().unwrap(),
+            Capability::SpacemitK1
+        );
+        assert_eq!(
+            "SPACEMIT-K3".parse::<Capability>().unwrap(),
+            Capability::SpacemitK3
+        );
     }
 
     #[test]
@@ -100,7 +109,11 @@ mod tests {
 
     #[test]
     fn display_round_trips_through_from_str() {
-        for cap in [Capability::GenericRvv1_0, Capability::SpacemitK1, Capability::SpacemitK3] {
+        for cap in [
+            Capability::GenericRvv1_0,
+            Capability::SpacemitK1,
+            Capability::SpacemitK3,
+        ] {
             assert_eq!(cap.to_string().parse::<Capability>().unwrap(), cap);
         }
     }

--- a/drivers/teeny-riscv/src/compiler/target.rs
+++ b/drivers/teeny-riscv/src/compiler/target.rs
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// RISC-V chip identifier passed to `teenyc` as `-C target-cpu` when compiling for the
+/// `riscv64-generic` target (see `rustc_target::spec::targets::riscv64_generic` and
+/// `rustc_codegen_llvm::mlir::target::resolve` in the `teeny` compiler fork).
+///
+/// Unlike [`teeny_cuda::compiler::target::Capability`]'s `sm_NN` values, these are **not** LLVM
+/// `-mcpu` names: the RISC-V backend (`RiscvBackend`) doesn't yet map them to real LLVM
+/// cpu/feature strings, so codegen currently always targets a fixed generic RV64GC baseline
+/// regardless of which variant is requested here. Once that mapping exists, this is the type
+/// that should carry it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Capability {
+    /// Generic RVV 1.0-capable core: no specific chip, just "has the V extension".
+    GenericRvv1_0,
+    /// SpacemiT K1 (e.g. Milk-V Duo, early SpacemiT boards).
+    SpacemitK1,
+    /// SpacemiT K3 (e.g. Milk-V Jupiter, Banana Pi BPI-F3).
+    SpacemitK3,
+}
+
+impl std::fmt::Display for Capability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::GenericRvv1_0 => "generic-rvv1.0",
+            Self::SpacemitK1 => "spacemit-k1",
+            Self::SpacemitK3 => "spacemit-k3",
+        };
+        f.write_str(s)
+    }
+}
+
+impl std::str::FromStr for Capability {
+    type Err = String;
+
+    /// Accepts the canonical hyphenated form, case-insensitively.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "generic-rvv1.0" | "generic-rvv1_0" => Ok(Self::GenericRvv1_0),
+            "spacemit-k1" => Ok(Self::SpacemitK1),
+            "spacemit-k3" => Ok(Self::SpacemitK3),
+            other => Err(format!(
+                "unknown RISC-V capability '{other}'; expected one of generic-rvv1.0, spacemit-k1, spacemit-k3"
+            )),
+        }
+    }
+}
+
+/// A RISC-V compilation target: a single chip [`Capability`].
+///
+/// Mirrors `teeny_cuda::compiler::target::Target`'s shape so call sites that are generic over
+/// [`teeny_core::compiler::Target`] work the same way for either backend.
+pub struct Target {
+    /// The target chip's capability.
+    pub capability: Capability,
+}
+
+impl Target {
+    /// Creates a target for the given chip `capability`.
+    pub fn new(capability: Capability) -> Self {
+        Self { capability }
+    }
+}
+
+impl teeny_core::compiler::Target for Target {
+    fn target_cpu(&self) -> Option<String> {
+        Some(self.capability.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Capability;
+
+    #[test]
+    fn accepts_canonical_forms() {
+        assert_eq!("generic-rvv1.0".parse::<Capability>().unwrap(), Capability::GenericRvv1_0);
+        assert_eq!("spacemit-k1".parse::<Capability>().unwrap(), Capability::SpacemitK1);
+        assert_eq!("SPACEMIT-K3".parse::<Capability>().unwrap(), Capability::SpacemitK3);
+    }
+
+    #[test]
+    fn rejects_unknown_capability() {
+        assert!("spacemit-k9".parse::<Capability>().is_err());
+    }
+
+    #[test]
+    fn display_round_trips_through_from_str() {
+        for cap in [Capability::GenericRvv1_0, Capability::SpacemitK1, Capability::SpacemitK3] {
+            assert_eq!(cap.to_string().parse::<Capability>().unwrap(), cap);
+        }
+    }
+}

--- a/drivers/teeny-riscv/src/errors.rs
+++ b/drivers/teeny-riscv/src/errors.rs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::PathBuf;
+
+/// `teeny-riscv`'s result alias.
+pub type Result<T> = anyhow::Result<T>;
+
+/// Errors produced by `teeny-riscv`.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// A capability string didn't match any known RISC-V chip identifier.
+    #[error("Unknown RISC-V capability: {0}")]
+    UnknownCapability(String),
+
+    /// Loading a compiled kernel's shared library failed (see [`libloading::Error`]).
+    #[error("failed to load kernel library {path:?}: {source}")]
+    LoadLibrary {
+        /// Path to the shared library that failed to load.
+        path: PathBuf,
+        /// The underlying `libloading` error.
+        #[source]
+        source: libloading::Error,
+    },
+
+    /// Resolving a symbol within a loaded kernel library failed.
+    #[error("failed to resolve symbol '{symbol}' in {path:?}: {source}")]
+    ResolveSymbol {
+        /// Path to the shared library the symbol was looked up in.
+        path: PathBuf,
+        /// The symbol name that failed to resolve.
+        symbol: String,
+        /// The underlying `libloading` error.
+        #[source]
+        source: libloading::Error,
+    },
+}

--- a/drivers/teeny-riscv/src/lib.rs
+++ b/drivers/teeny-riscv/src/lib.rs
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! The RISC-V device backend for [teenygrad](https://teenygrad.org) — `Target`/`Capability`
+//! types for the `mlir`/Triton compiler backend's `riscv64-generic` path ([`compiler`]), and a
+//! `libloading`-based runtime for loading a compiled kernel's shared library and calling its
+//! exported symbol ([`runtime`]).
+//!
+//! See the crate README for current status: the underlying compiler backend is an early stub, so
+//! only the placeholder no-argument kernel it always produces can be compiled/loaded today.
+
+#![warn(missing_docs)]
+
+/// `Target`/`Capability` types for compiling kernels via `LlvmCompiler`.
+pub mod compiler;
+/// Error types.
+pub mod errors;
+/// Loading and calling a compiled kernel's shared library.
+pub mod runtime;

--- a/drivers/teeny-riscv/src/runtime/mod.rs
+++ b/drivers/teeny-riscv/src/runtime/mod.rs
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::path::{Path, PathBuf};
+
+use libloading::{Library, Symbol};
+
+use crate::errors::{Error, Result};
+
+/// A dlopen'd kernel shared library, as produced by `LlvmCompiler::compile` targeting
+/// [`crate::compiler::TARGET_TRIPLE`] (see `RiscvBackend::makeBIN` in the `teeny` compiler fork,
+/// which links the compiled kernel into a real ELF shared library via `ld.lld`).
+///
+/// This only makes sense to actually load on RISC-V (native, or under user-mode emulation like
+/// `qemu-riscv64`) -- `dlopen`-ing a RISC-V `.so` from an x86_64 process fails immediately with
+/// an architecture mismatch. See the crate README for how this was verified during development.
+pub struct KernelLibrary {
+    path: PathBuf,
+    lib: Library,
+}
+
+impl KernelLibrary {
+    /// Loads the kernel shared library at `path`.
+    pub fn load(path: impl Into<PathBuf>) -> Result<Self> {
+        let path = path.into();
+        // Safety: loading an arbitrary shared library is inherently unsafe -- its
+        // initializers run immediately, and any symbol resolved from it must be
+        // called with a signature matching what the compiler actually generated.
+        // The caller is responsible for path being a kernel library this backend
+        // produced, not arbitrary/untrusted input.
+        let lib = unsafe { Library::new(&path) }
+            .map_err(|source| Error::LoadLibrary { path: path.clone(), source })?;
+        Ok(Self { path, lib })
+    }
+
+    /// Path this library was loaded from.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Resolves `symbol` as a no-argument, no-return kernel entry point (the shape
+    /// `RiscvBackend::makeLLVMIR` currently always generates -- see the crate README) and calls
+    /// it.
+    ///
+    /// # Safety
+    /// The caller must ensure `symbol` actually refers to a function with the `extern "C" fn()`
+    /// signature. Calling with a mismatched signature is undefined behavior.
+    pub unsafe fn call_void_kernel(&self, symbol: &str) -> Result<()> {
+        // Safety: forwarded to the caller via this function's own safety contract.
+        let func: Symbol<unsafe extern "C" fn()> = unsafe { self.lib.get(symbol.as_bytes()) }
+            .map_err(|source| Error::ResolveSymbol {
+                path: self.path.clone(),
+                symbol: symbol.to_string(),
+                source,
+            })?;
+        unsafe { func() };
+        Ok(())
+    }
+}

--- a/drivers/teeny-riscv/src/runtime/mod.rs
+++ b/drivers/teeny-riscv/src/runtime/mod.rs
@@ -41,8 +41,10 @@ impl KernelLibrary {
         // called with a signature matching what the compiler actually generated.
         // The caller is responsible for path being a kernel library this backend
         // produced, not arbitrary/untrusted input.
-        let lib = unsafe { Library::new(&path) }
-            .map_err(|source| Error::LoadLibrary { path: path.clone(), source })?;
+        let lib = unsafe { Library::new(&path) }.map_err(|source| Error::LoadLibrary {
+            path: path.clone(),
+            source,
+        })?;
         Ok(Self { path, lib })
     }
 

--- a/drivers/teeny-riscv/tests/test_compile_riscv.rs
+++ b/drivers/teeny-riscv/tests/test_compile_riscv.rs
@@ -50,16 +50,32 @@ fn compiles_to_a_riscv_elf_shared_library() -> anyhow::Result<()> {
     let cache_dir = teeny_compiler::compiler::default_cache_dir();
     let compiler = LlvmCompiler::new(teenyc_path, cache_dir)?
         .with_target_triple(TARGET_TRIPLE)
-        .with_target_cpu(target.target_cpu().expect("Target::target_cpu is always Some"));
+        .with_target_cpu(
+            target
+                .target_cpu()
+                .expect("Target::target_cpu is always Some"),
+        );
 
     let output_path = compiler.compile(&kernel, &target, true)?;
     let bytes = std::fs::read(&output_path)?;
 
-    assert_eq!(&bytes[..4], b"\x7fELF", "expected a real ELF file, not assembly/PTX text");
+    assert_eq!(
+        &bytes[..4],
+        b"\x7fELF",
+        "expected a real ELF file, not assembly/PTX text"
+    );
     // e_type at offset 16 (u16 LE): ET_DYN (3) for a shared object.
-    assert_eq!(u16::from_le_bytes([bytes[16], bytes[17]]), 3, "expected ET_DYN (shared object)");
+    assert_eq!(
+        u16::from_le_bytes([bytes[16], bytes[17]]),
+        3,
+        "expected ET_DYN (shared object)"
+    );
     // e_machine at offset 18 (u16 LE): EM_RISCV (243).
-    assert_eq!(u16::from_le_bytes([bytes[18], bytes[19]]), 243, "expected EM_RISCV");
+    assert_eq!(
+        u16::from_le_bytes([bytes[18], bytes[19]]),
+        243,
+        "expected EM_RISCV"
+    );
 
     Ok(())
 }

--- a/drivers/teeny-riscv/tests/test_compile_riscv.rs
+++ b/drivers/teeny-riscv/tests/test_compile_riscv.rs
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 Teenygrad.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Compiles a real kernel through `teenyc`'s RISC-V path and checks that the output is a
+//! well-formed RISC-V ELF shared library.
+//!
+//! `RiscvBackend` (in the `teeny` compiler fork) is still a stub: every kernel compiles to the
+//! same placeholder no-argument `void @<name>()` function regardless of source (see the crate
+//! README), so this deliberately doesn't check the kernel's *behavior* -- there isn't one yet --
+//! only that the compile pipeline (real LLVM RISC-V codegen, linked via `ld.lld`) produces a
+//! genuine RISC-V shared object.
+//!
+//! Actually loading and calling it (via [`teeny_riscv::runtime::KernelLibrary`]) requires running
+//! on RISC-V (native, or under `qemu-riscv64`); this was verified manually during development
+//! (cross-compiling a small dlopen/dlsym harness for riscv64-linux-gnu and running it under QEMU
+//! against the .so this test produces) but isn't exercised here, since that needs the test binary
+//! itself to run on RISC-V, not just the kernel.
+
+use dotenv::dotenv;
+use teeny_compiler::compiler::backend::llvm::compiler::LlvmCompiler;
+use teeny_core::compiler::{Compiler, Target as _};
+use teeny_core::device::program::Kernel;
+use teeny_kernels::nn::activation::relu::ReluForward;
+use teeny_riscv::compiler::TARGET_TRIPLE;
+use teeny_riscv::compiler::target::{Capability, Target};
+
+const BLOCK_SIZE: i32 = 1024;
+
+#[test]
+fn compiles_to_a_riscv_elf_shared_library() -> anyhow::Result<()> {
+    dotenv().ok();
+
+    let kernel = ReluForward::<f32>::new(BLOCK_SIZE);
+    let target = Target::new(Capability::GenericRvv1_0);
+
+    let teenyc_path = teeny_compiler::compiler::find_teenyc()?;
+    let cache_dir = teeny_compiler::compiler::default_cache_dir();
+    let compiler = LlvmCompiler::new(teenyc_path, cache_dir)?
+        .with_target_triple(TARGET_TRIPLE)
+        .with_target_cpu(target.target_cpu().expect("Target::target_cpu is always Some"));
+
+    let output_path = compiler.compile(&kernel, &target, true)?;
+    let bytes = std::fs::read(&output_path)?;
+
+    assert_eq!(&bytes[..4], b"\x7fELF", "expected a real ELF file, not assembly/PTX text");
+    // e_type at offset 16 (u16 LE): ET_DYN (3) for a shared object.
+    assert_eq!(u16::from_le_bytes([bytes[16], bytes[17]]), 3, "expected ET_DYN (shared object)");
+    // e_machine at offset 18 (u16 LE): EM_RISCV (243).
+    assert_eq!(u16::from_le_bytes([bytes[18], bytes[19]]), 243, "expected EM_RISCV");
+
+    Ok(())
+}

--- a/kernels/teeny-kernels/src/testing.rs
+++ b/kernels/teeny-kernels/src/testing.rs
@@ -51,8 +51,10 @@ pub fn load_fixture(rel: &str) -> Vec<f32> {
     let path = format!("{}/tests/fixtures/{}", env!("CARGO_MANIFEST_DIR"), rel);
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("missing fixture {path}: {e}"));
     bytes
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 
@@ -61,8 +63,10 @@ pub fn load_fixture_i32(rel: &str) -> Vec<i32> {
     let path = format!("{}/tests/fixtures/{}", env!("CARGO_MANIFEST_DIR"), rel);
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("missing fixture {path}: {e}"));
     bytes
-        .chunks_exact(4)
-        .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| i32::from_le_bytes(*b))
         .collect()
 }
 

--- a/kernels/teeny-kernels/tests/test_channel_bias_add.rs
+++ b/kernels/teeny-kernels/tests/test_channel_bias_add.rs
@@ -41,8 +41,10 @@ fn load(rel: &str) -> Vec<f32> {
     let path = format!("{}/tests/fixtures/{}", env!("CARGO_MANIFEST_DIR"), rel);
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("missing {path}: {e}"));
     bytes
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 

--- a/kernels/teeny-kernels/tests/test_elemwise_add.rs
+++ b/kernels/teeny-kernels/tests/test_elemwise_add.rs
@@ -39,8 +39,10 @@ fn load(rel: &str) -> Vec<f32> {
     let path = format!("{}/tests/fixtures/{}", env!("CARGO_MANIFEST_DIR"), rel);
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("missing {path}: {e}"));
     bytes
-        .chunks_exact(4)
-        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| f32::from_le_bytes(*b))
         .collect()
 }
 

--- a/utilities/teeny-quant/src/read.rs
+++ b/utilities/teeny-quant/src/read.rs
@@ -35,18 +35,24 @@ pub fn read_f32(view: &TensorView<'_>, name: &str) -> Result<Vec<f32>> {
     match view.dtype() {
         Dtype::F32 => Ok(view
             .data()
-            .chunks_exact(4)
-            .map(|b| f32::from_le_bytes(b.try_into().expect("chunks_exact(4)")))
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|b| f32::from_le_bytes(*b))
             .collect()),
         Dtype::F16 => Ok(view
             .data()
-            .chunks_exact(2)
-            .map(|b| f16::from_le_bytes(b.try_into().expect("chunks_exact(2)")).to_f32())
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|b| f16::from_le_bytes(*b).to_f32())
             .collect()),
         Dtype::BF16 => Ok(view
             .data()
-            .chunks_exact(2)
-            .map(|b| bf16::from_le_bytes(b.try_into().expect("chunks_exact(2)")).to_f32())
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|b| bf16::from_le_bytes(*b).to_f32())
             .collect()),
         other => Err(Error::UnsupportedDtype {
             tensor: name.to_string(),

--- a/utilities/teeny-quant/src/validate.rs
+++ b/utilities/teeny-quant/src/validate.rs
@@ -200,8 +200,10 @@ pub fn validate_checkpoint(
             Some(
                 zp_view
                     .data()
-                    .chunks_exact(4)
-                    .map(|b| i32::from_le_bytes(b.try_into().expect("chunks_exact(4)")))
+                    .as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|b| i32::from_le_bytes(*b))
                     .collect::<Vec<_>>(),
             )
         };

--- a/utilities/teeny-quant/tests/quantize_roundtrip.rs
+++ b/utilities/teeny-quant/tests/quantize_roundtrip.rs
@@ -118,8 +118,10 @@ fn assert_round_trips(scheme: Scheme, granularity: Granularity, max_tol_fraction
         Some(
             zp_view
                 .data()
-                .chunks_exact(4)
-                .map(|b| i32::from_le_bytes(b.try_into().unwrap()))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|b| i32::from_le_bytes(*b))
                 .collect::<Vec<_>>(),
         )
     };


### PR DESCRIPTION
## Summary
- Make `teenyc`'s `--target` triple configurable so `teeny-compiler` can target RISC-V, not just the hardcoded `nvptx64-nvidia-cuda` triple.
- Add a `teeny-riscv` driver crate scaffold (Cargo.toml, target/capability definitions, runtime kernel-loading via `libloading`), mirroring the existing `teeny-cuda` driver.

Cherry-picked from `feature/riscv-target-support` (based on `main`) onto `release/0.2.1` since that branch has diverged significantly from `main`.

## Test plan
- [x] `cargo check -p teeny-riscv -p teeny-compiler` passes on `release/0.2.1`
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XNjoKzedWFTG5eemPQjJP