### PR TITLE
chore: add pre-push clippy hook mirroring CI's lint gate

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,15 @@
+# Git hooks
+
+Hooks in this directory aren't active until you point git at them (git
+doesn't do this automatically, and `.git/hooks` isn't version-controlled):
+
+```sh
+git config core.hooksPath .githooks
+```
+
+Run that once per clone (or worktree, since `core.hooksPath` is a local
+config setting). `setup_ubuntu.sh` does this for you.
+
+- `pre-push` — runs the same `cargo clippy -- -D warnings` check as CI's
+  "Build, test, clippy" job, so a lint regression is caught locally before
+  it fails the pipeline.

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Mirrors the "Clippy" step of .github/workflows/ci.yml's build-test-clippy
+# job, so lint regressions (e.g. a new clippy lint tripping on old code) are
+# caught before a push triggers CI, not after.
+#
+# Enabled via `git config core.hooksPath .githooks` (see .githooks/README.md).
+
+set -e
+
+echo "pre-push: cargo clippy --workspace --exclude teeny-torch -- -D warnings"
+cargo clippy --workspace --exclude teeny-torch -- -D warnings

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -27,3 +27,6 @@ if [ "$RELOGIN_REQUIRED" = true ]; then
     echo "Please logout and login again, as new tools are installed"
     exit 0
 fi
+
+# use the repo's versioned hooks (see .githooks/README.md)
+git config core.hooksPath .githooks


### PR DESCRIPTION
## Summary
- Add `.githooks/pre-push`, running the same `cargo clippy --workspace --exclude teeny-torch -- -D warnings` check as CI's "Build, test, clippy" job, so a lint regression (e.g. a new clippy lint tripping on old, previously-clean code, as happened on #37) is caught locally before a push triggers CI.
- `setup_ubuntu.sh` now runs `git config core.hooksPath .githooks` so this is on by default for new clones; `.githooks/README.md` documents the one-liner for existing clones/worktrees.

## Test plan
- [x] Verified the hook fires on `git push` and blocks on a genuine build failure
- [x] Verified a clean push proceeds once the workspace passes clippy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018XNjoKzedWFTG5eemPQjJP